### PR TITLE
Cleaning things up part two

### DIFF
--- a/bin/seed.js
+++ b/bin/seed.js
@@ -218,7 +218,6 @@ const createCommentObjects = (
   for (let i = 0; i < stretchAnswers.length; ++i) {
     const { userId, id, cohortstretchId } = stretchAnswers[i]
     const { cohortId } = cohortStretches.find(cs => cs.id === cohortstretchId)
-    console.log(cohortId)
     const users = cohortUsers
       .filter(cu => adminIds.includes(cu.userId) && cu.cohortId === cohortId)
       .map(cu => cu.userId)

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -152,7 +152,7 @@ const createStretchAnswerObjects = (cohortStretchs, cohortUsers) => {
   const csClosed = cohortStretchs.filter(cs => cs.status === 'closed')
 
   for (let i = 0; i < csClosed.length; ++i) {
-    const { cohortId } = cohortStretchs[i]
+    const { cohortId } = csClosed[i]
     const students = cohortUsers
       .filter(cu => cu.cohortId === cohortId)
       .map(cu => cu.userId)
@@ -179,7 +179,7 @@ const createStretchAnswerObjects = (cohortStretchs, cohortUsers) => {
 
   const csOpen = cohortStretchs.filter(cs => cs.status === 'open')
   for (let i = 0; i < csOpen.length; ++i) {
-    const { cohortId } = cohortStretchs[i]
+    const { cohortId } = csOpen[i]
     const students = cohortUsers
       .filter(cu => cu.cohortId === cohortId)
       .map(cu => cu.userId)

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -101,7 +101,7 @@ const createStretchObjects = (userIds, categoryIds) => {
       codePrompt: paragraph(),
       difficulty:
         Math.random() <= 0.7 ? getRandomArrayEntry([1, 2, 3, 4, 5]) : null,
-      canBeCoded: Math.random() <= 0.7,
+      minutes: getRandomArrayEntry([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
       authorId: getRandomArrayEntry(userIds),
       categoryId: getRandomArrayEntry(categoryIds)
     }
@@ -120,7 +120,6 @@ const createCohortStretchObjects = (cohortIds, stretchIds) => {
         status,
         allowAnswersToBeRun: Math.random() <= 0.3,
         solution: paragraph(),
-        minutes: getRandomArrayEntry([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
         cohortId: cohortIds[j],
         stretchId: getRandomArrayEntry(stretchIdsTemp),
         scheduledDate: new Date(

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -118,7 +118,7 @@ const createCohortStretchObjects = (cohortIds, stretchIds) => {
       const status = i === 0 ? 'scheduled' : i === 1 ? 'open' : 'closed'
       let cohortStretch = {
         status,
-        allowAnswersToBeRun: Math.random() <= 0.3,
+        allowAnswersToBeRun: Math.random() <= 0.5,
         solution: paragraph(),
         cohortId: cohortIds[j],
         stretchId: getRandomArrayEntry(stretchIdsTemp),

--- a/client/Components/AdminController/AdminController.js
+++ b/client/Components/AdminController/AdminController.js
@@ -9,7 +9,6 @@ import StudentClosedStretchView from '../StudentClosedStretchView'
 
 class AdminController extends Component {
   render() {
-    console.log('in render')
     return (
       <div>
         <Route path="/admin" exact component={AdminHomeView} />

--- a/client/Components/AdminController/AdminController.js
+++ b/client/Components/AdminController/AdminController.js
@@ -40,7 +40,7 @@ class AdminController extends Component {
 
         {/* path to go to view student's stretchAnswer to see their oslution, comments*/}
         <Route
-          path="/admin/stretchAnswer/:stretchAnswerId"
+          path="/admin/stretchAnswer/:stretchAnswerId/student/:studentId"
           exact
           component={StudentClosedStretchView}
         />

--- a/client/Components/AdminHomeView/AdminHomeView.js
+++ b/client/Components/AdminHomeView/AdminHomeView.js
@@ -55,7 +55,6 @@ const AdminHomeView = ({ openStretches, scheduledStretches, history }) => {
       {showScheduled && scheduledStretches.length ? (
         <Grid container style={styles.stretchesGrid}>
           {scheduledStretches.map(stretch => {
-            console.log(stretch)
             return (
               <Grid item xs={5} key={stretch.id}>
                 <SingleStretchCard stretch={stretch} status="scheduled" />

--- a/client/Components/AdminHomeView/helperfunctions.js
+++ b/client/Components/AdminHomeView/helperfunctions.js
@@ -39,7 +39,8 @@ export const getFilteredStretchesOfAdmin = (
       stretchId: value.id,
       title: value.title,
       category: value.categoryName,
-      difficulty: value.difficulty
+      difficulty: value.difficulty,
+      minutes: value.minutes
     }
     return obj
   }, {})

--- a/client/Components/App.js
+++ b/client/Components/App.js
@@ -4,7 +4,6 @@ import { HashRouter as Router, Route } from 'react-router-dom'
 
 // Redux imports
 import { connect } from 'react-redux'
-import { checkIfUserLoggedInThunk } from '../store/auth/actions'
 
 import { getAllCohorts } from '../store/cohorts/actions'
 import { getAllCohortUsers } from '../store/cohort-users/actions'
@@ -18,7 +17,6 @@ import { Login, AdminController, StudentController } from './index'
 
 class App extends Component {
   componentDidMount() {
-    this.props.checkIfUserLoggedIn()
     this.props.load()
   }
 
@@ -37,8 +35,6 @@ class App extends Component {
 
 const mapDispatchToProps = dispatch => {
   return {
-    checkIfUserLoggedIn: () => dispatch(checkIfUserLoggedInThunk()),
-
     load: () => {
       dispatch(getAllCohorts())
       dispatch(getAllCohortUsers())

--- a/client/Components/App.js
+++ b/client/Components/App.js
@@ -4,29 +4,25 @@ import { HashRouter as Router, Route } from 'react-router-dom'
 
 // Redux imports
 import { connect } from 'react-redux'
-
-import { getAllCohorts } from '../store/cohorts/actions'
-import { getAllCohortUsers } from '../store/cohort-users/actions'
-import { getAllCategories } from '../store/categories/actions'
-import { getAllStretches } from '../store/stretches/actions'
-import { getAllStretchAnswers } from '../store/stretch-answers/actions'
-import { getAllCohortStretches } from '../store/cohort-stretches/actions'
+import { checkIfUserLoggedInThunk } from '../store/auth/actions'
 
 // React sub-components
 import { Login, AdminController, StudentController } from './index'
 
 class App extends Component {
   componentDidMount() {
-    this.props.load()
+    this.props.checkIfUserLoggedIn()
   }
 
   render() {
+    const { id } = this.props.userDetails
     return (
       <Router>
         <Fragment>
-          <Route path="/" exact component={Login} />
-          <Route path="/admin" component={AdminController} />
-          <Route path="/student" component={StudentController} />
+          {!id && <Route component={Login} />}
+          {id && <Route path="/" exact component={Login} />}
+          {id && <Route path="/admin" component={AdminController} />}
+          {id && <Route path="/student" component={StudentController} />}
         </Fragment>
       </Router>
     )
@@ -35,18 +31,13 @@ class App extends Component {
 
 const mapDispatchToProps = dispatch => {
   return {
-    load: () => {
-      dispatch(getAllCohorts())
-      //dispatch(getAllCohortUsers())
-      dispatch(getAllCategories())
-      dispatch(getAllStretches())
-      //dispatch(getAllStretchAnswers())
-      dispatch(getAllCohortStretches())
-    }
+    checkIfUserLoggedIn: () => dispatch(checkIfUserLoggedInThunk())
   }
 }
 
+const mapStateToProps = ({ userDetails }) => ({ userDetails })
+
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(App)

--- a/client/Components/App.js
+++ b/client/Components/App.js
@@ -40,7 +40,7 @@ const mapDispatchToProps = dispatch => {
       dispatch(getAllCohortUsers())
       dispatch(getAllCategories())
       dispatch(getAllStretches())
-      dispatch(getAllStretchAnswers())
+      //dispatch(getAllStretchAnswers())
       dispatch(getAllCohortStretches())
     }
   }

--- a/client/Components/App.js
+++ b/client/Components/App.js
@@ -37,7 +37,7 @@ const mapDispatchToProps = dispatch => {
   return {
     load: () => {
       dispatch(getAllCohorts())
-      dispatch(getAllCohortUsers())
+      //dispatch(getAllCohortUsers())
       dispatch(getAllCategories())
       dispatch(getAllStretches())
       //dispatch(getAllStretchAnswers())

--- a/client/Components/CodeEditor/functions.js
+++ b/client/Components/CodeEditor/functions.js
@@ -4,7 +4,6 @@ const runCode = function(code) {
   return axios
     .post('/api/code/runcode', { code })
     .then(res => {
-      console.log(res)
       this.setState({
         codeResponse: String(res.data),
         codeError: ''

--- a/client/Components/FrameworkHOC/FrameworkHOC.js
+++ b/client/Components/FrameworkHOC/FrameworkHOC.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { getCohortsOfAdminThunk } from '../../store/cohorts/actions'
 import { getStretchAnswersOfSingleAdminThunk } from '../../store/stretch-answers/actions'
 import { getUsersOfSingleAdminThunk } from '../../store/users/actions'
+import { checkIfUserLoggedInThunk } from '../../store/auth/actions'
 import Drawer from '@material-ui/core/Drawer'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import AppBar from '@material-ui/core/AppBar'
@@ -18,7 +19,17 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
   const Framework = props => {
     const classes = useStyles()
     const [open, setOpen] = useState(false)
-    const { userDetails, history, loadAdminRelatedData } = props
+    const {
+      userDetails,
+      history,
+      loadAdminRelatedData,
+      checkIfUserLoggedIn
+    } = props
+    useEffect(() => {
+      if (!userDetails.id) {
+        checkIfUserLoggedIn(history)
+      }
+    })
     useEffect(() => {
       if (userDetails.id) {
         loadAdminRelatedData(userDetails.id)
@@ -90,6 +101,8 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
 
   const mapDispatchToProps = dispatch => {
     return {
+      checkIfUserLoggedIn: history =>
+        dispatch(checkIfUserLoggedInThunk(history)),
       loadAdminRelatedData: adminId => {
         return Promise.all([
           dispatch(getCohortsOfAdminThunk(adminId)),

--- a/client/Components/FrameworkHOC/FrameworkHOC.js
+++ b/client/Components/FrameworkHOC/FrameworkHOC.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux'
 import { getCohortsOfAdminThunk } from '../../store/cohorts/actions'
 import { getStretchAnswersOfSingleAdminThunk } from '../../store/stretch-answers/actions'
 import { getUsersOfSingleAdminThunk } from '../../store/users/actions'
-import { checkIfUserLoggedInThunk } from '../../store/auth/actions'
+import {
+  checkIfUserLoggedInThunk,
+  logoutUserThunk
+} from '../../store/auth/actions'
 import Drawer from '@material-ui/core/Drawer'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import AppBar from '@material-ui/core/AppBar'
@@ -11,6 +14,7 @@ import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
 import Divider from '@material-ui/core/Divider'
 import IconButton from '@material-ui/core/IconButton'
+import Button from '@material-ui/core/Button'
 import MenuIcon from '@material-ui/icons/Menu'
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
 import useStyles from './styles'
@@ -23,7 +27,8 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
       userDetails,
       history,
       loadAdminRelatedData,
-      checkIfUserLoggedIn
+      checkIfUserLoggedIn,
+      logoutUser
     } = props
     useEffect(() => {
       if (!userDetails.id) {
@@ -66,6 +71,9 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
             >
               Modern Stretches
             </Typography>
+            <Button color="inherit" onClick={() => logoutUser(history)}>
+              Logout
+            </Button>
           </Toolbar>
         </AppBar>
         <Drawer
@@ -103,6 +111,7 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
     return {
       checkIfUserLoggedIn: history =>
         dispatch(checkIfUserLoggedInThunk(history)),
+      logoutUser: history => dispatch(logoutUserThunk(history)),
       loadAdminRelatedData: adminId => {
         return Promise.all([
           dispatch(getCohortsOfAdminThunk(adminId)),

--- a/client/Components/FrameworkHOC/FrameworkHOC.js
+++ b/client/Components/FrameworkHOC/FrameworkHOC.js
@@ -1,12 +1,16 @@
 import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { getCohortsOfAdminThunk } from '../../store/cohorts/actions'
-import { getStretchAnswersOfSingleAdminThunk } from '../../store/stretch-answers/actions'
+import {
+  getStretchAnswersOfSingleAdminThunk,
+  getStretchAnswersOfStudentThunk
+} from '../../store/stretch-answers/actions'
 import { getUsersOfSingleAdminThunk } from '../../store/users/actions'
 import {
   checkIfUserLoggedInThunk,
   logoutUserThunk
 } from '../../store/auth/actions'
+import { getStudentCohortUsersThunk } from '../../store/cohort-users/actions'
 import Drawer from '@material-ui/core/Drawer'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import AppBar from '@material-ui/core/AppBar'
@@ -27,6 +31,7 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
       userDetails,
       history,
       loadAdminRelatedData,
+      loadStudentRelatedData,
       checkIfUserLoggedIn,
       logoutUser
     } = props
@@ -36,8 +41,11 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
       }
     })
     useEffect(() => {
-      if (userDetails.id) {
+      if (userDetails.id && userDetails.isAdmin) {
         loadAdminRelatedData(userDetails.id)
+      }
+      if (userDetails.id && !userDetails.isAdmin) {
+        loadStudentRelatedData(userDetails.id)
       }
     }, [userDetails])
 
@@ -117,6 +125,12 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
           dispatch(getCohortsOfAdminThunk(adminId)),
           dispatch(getStretchAnswersOfSingleAdminThunk(adminId)),
           dispatch(getUsersOfSingleAdminThunk(adminId))
+        ])
+      },
+      loadStudentRelatedData: studentId => {
+        return Promise.all([
+          dispatch(getStretchAnswersOfStudentThunk(studentId)),
+          dispatch(getStudentCohortUsersThunk(studentId))
         ])
       }
     }

--- a/client/Components/FrameworkHOC/FrameworkHOC.js
+++ b/client/Components/FrameworkHOC/FrameworkHOC.js
@@ -11,6 +11,10 @@ import {
   logoutUserThunk
 } from '../../store/auth/actions'
 import { getStudentCohortUsersThunk } from '../../store/cohort-users/actions'
+import { getAllCategories } from '../../store/categories/actions'
+import { getAllStretches } from '../../store/stretches/actions'
+import { getAllCohortStretches } from '../../store/cohort-stretches/actions'
+
 import Drawer from '@material-ui/core/Drawer'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import AppBar from '@material-ui/core/AppBar'
@@ -32,14 +36,8 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
       history,
       loadAdminRelatedData,
       loadStudentRelatedData,
-      checkIfUserLoggedIn,
       logoutUser
     } = props
-    useEffect(() => {
-      if (!userDetails.id) {
-        checkIfUserLoggedIn(history)
-      }
-    })
     useEffect(() => {
       if (userDetails.id && userDetails.isAdmin) {
         loadAdminRelatedData(userDetails.id)
@@ -116,6 +114,12 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
   const mapStateToProps = ({ userDetails }) => ({ userDetails })
 
   const mapDispatchToProps = dispatch => {
+    const commonData = [
+      dispatch(getAllCategories()),
+      dispatch(getAllStretches()),
+      dispatch(getAllCohortStretches())
+    ]
+
     return {
       checkIfUserLoggedIn: history =>
         dispatch(checkIfUserLoggedInThunk(history)),
@@ -124,13 +128,15 @@ const FrameworkHOC = (MainComponent, Sidebar) => {
         return Promise.all([
           dispatch(getCohortsOfAdminThunk(adminId)),
           dispatch(getStretchAnswersOfSingleAdminThunk(adminId)),
-          dispatch(getUsersOfSingleAdminThunk(adminId))
+          dispatch(getUsersOfSingleAdminThunk(adminId)),
+          ...commonData
         ])
       },
       loadStudentRelatedData: studentId => {
         return Promise.all([
           dispatch(getStretchAnswersOfStudentThunk(studentId)),
-          dispatch(getStudentCohortUsersThunk(studentId))
+          dispatch(getStudentCohortUsersThunk(studentId)),
+          ...commonData
         ])
       }
     }

--- a/client/Components/OpenStretchView/CodeSectionNoRun.js
+++ b/client/Components/OpenStretchView/CodeSectionNoRun.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+import CodeEditor, { AuxillaryComponents } from '../CodeEditor'
+const { ThemeSelector } = AuxillaryComponents
+import Grid from '@material-ui/core/Grid'
+
+const CodeSectionNoRun = ({ codePrompt, setStretchAnswer }) => {
+  const [editorTheme, setEditorTheme] = useState('monokai')
+  return (
+    <Grid container>
+      <Grid item xs={12}>
+        <ThemeSelector
+          editorTheme={editorTheme}
+          handleChange={({ target }) => setEditorTheme(target.value)}
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <CodeEditor
+          codeTargetName="code"
+          initialCode={codePrompt}
+          editorTheme={editorTheme}
+          handleCodeChange={({ target }) => setStretchAnswer(target.value)}
+        />
+      </Grid>
+    </Grid>
+  )
+}
+
+export default CodeSectionNoRun

--- a/client/Components/OpenStretchView/CodeSectionRun.js
+++ b/client/Components/OpenStretchView/CodeSectionRun.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react'
+import CodeEditor, {
+  AuxillaryComponents,
+  codeEditorFunctions
+} from '../CodeEditor'
+const { runCode, clearCodeResults } = codeEditorFunctions
+const {
+  ThemeSelector,
+  RunCodeButton,
+  ClearCodeResultsButton,
+  CodeOutput
+} = AuxillaryComponents
+
+import Grid from '@material-ui/core/Grid'
+import { codeSectionStyles } from '../StretchReviewView/styles'
+
+class CodeSectionRun extends Component {
+  constructor() {
+    super()
+    this.state = {
+      editorTheme: 'monokai',
+      codeResponse: '',
+      codeError: ''
+    }
+    this.runCodeBinded = runCode.bind(this)
+    this.clearCodeResultsBinded = clearCodeResults.bind(this)
+  }
+
+  handleChange = ({ target }) => {
+    this.setState({ [target.name]: target.value })
+  }
+
+  render() {
+    const { editorTheme, codeResponse, codeError } = this.state
+    const { runCodeBinded, clearCodeResultsBinded, handleChange } = this
+    const { codePrompt, setStretchAnswer, stretchAnswer } = this.props
+    return (
+      <div>
+        <Grid container>
+          <Grid item xs={6}>
+            <ThemeSelector {...{ editorTheme, handleChange }} />
+          </Grid>
+          <Grid item xs={6}>
+            <Grid container style={codeSectionStyles.controls}>
+              <Grid item xs={12}>
+                <RunCodeButton
+                  color="primary"
+                  runCode={runCodeBinded}
+                  code={stretchAnswer}
+                />
+                <ClearCodeResultsButton
+                  color="secondary"
+                  clearCodeResults={clearCodeResultsBinded}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid container>
+          <Grid item xs={6}>
+            <CodeEditor
+              codeTargetName="code"
+              initialCode={codePrompt}
+              editorTheme={editorTheme}
+              handleCodeChange={({ target }) => setStretchAnswer(target.value)}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <CodeOutput
+              codeResponse={codeResponse}
+              codeError={codeError}
+              minHeight="23rem"
+            />
+          </Grid>
+        </Grid>
+      </div>
+    )
+  }
+}
+
+export default CodeSectionRun

--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -59,11 +59,11 @@ const OpenStretchView = ({
       setCodePrompt(myStretch.codePrompt)
       setStretchAnswer(myStretch.codePrompt)
     }
-    if (myCohortStretch && !remainingTime) {
-      setDisplayMinutes(myCohortStretch.minutes - 1)
-      setRemainingTime(myCohortStretch.minutes * 60)
+    if (myStretch && !remainingTime) {
+      setDisplayMinutes(myStretch.minutes - 1)
+      setRemainingTime(myStretch.minutes * 60)
     }
-    if (myCohortStretch && remainingTime) {
+    if (myStretch && remainingTime) {
       const timer = setTimeout(() => {
         setRemainingTime(remainingTime - 1)
         if (displaySeconds > 0) {
@@ -77,7 +77,7 @@ const OpenStretchView = ({
         clearTimeout(timer)
         createStretchAnswer({
           body: stretchAnswer,
-          timeToSolve: myCohortStretch.minutes * 60 - remainingTime,
+          timeToSolve: myStretch.minutes * 60 - remainingTime,
           cohortstretchId: myCohortStretch.id,
           userId: userDetails.id
         })
@@ -119,7 +119,7 @@ const OpenStretchView = ({
         onClick={() =>
           createStretchAnswer({
             body: stretchAnswer,
-            timeToSolve: myCohortStretch.minutes * 60 - remainingTime,
+            timeToSolve: myStretch.minutes * 60 - remainingTime,
             cohortstretchId: myCohortStretch.id,
             userId: userDetails.id
           })

--- a/client/Components/SingleCohort/CohortStudents.js
+++ b/client/Components/SingleCohort/CohortStudents.js
@@ -2,13 +2,6 @@ import React from 'react'
 import SubmittedStretches from './SubmittedStretches'
 
 export const CohortStudents = ({ cohortStudents }) => {
-<<<<<<< HEAD
-
-    return (<div>
-        {cohortStudents.map(student => <SubmittedStretches student={student} />)}
-
-    </div>)
-=======
   console.log(cohortStudents)
   return (
     <div>
@@ -17,5 +10,4 @@ export const CohortStudents = ({ cohortStudents }) => {
       ))}
     </div>
   )
->>>>>>> upstream/develop
 }

--- a/client/Components/SingleCohort/SingleCohortStretchTables.js
+++ b/client/Components/SingleCohort/SingleCohortStretchTables.js
@@ -6,6 +6,7 @@ import {
   deleteCohortStretchThunk,
   updateCohortStretchThunk
 } from '../../store/cohort-stretches/actions'
+import { checkIfAllDataExists } from '../../utilityfunctions'
 
 import StretchScheduler from '../_shared/StretchScheduler'
 import ConfirmDialogBox from '../_shared/ConfirmDialogBox'
@@ -24,6 +25,9 @@ const SingleCohortStretchTables = ({
   deleteCohortStretch,
   updateCohortStretch
 }) => {
+  if (!checkIfAllDataExists(cohort, cohortStretches, stretches)) {
+    return <div>No open, scheduled, or submitted stretches for cohort</div>
+  }
   let [rescheduleModalOpen, setRescheduleModalOpen] = useState(false)
   let [unscheduleModalOpen, setunscheduleModalOpen] = useState(false)
   let [openStretchModalOpen, setOpenStretchModalOpen] = useState(false)
@@ -35,9 +39,12 @@ const SingleCohortStretchTables = ({
       cohortStretch => cohortStretch.cohortId === cohort.id
     ) || []
   const openCohortStretches =
-    thisCohortStretches.filter(
-      cohortStretches => cohortStretches.status === 'open'
-    ) || []
+    thisCohortStretches
+      .filter(cohortStretches => cohortStretches.status === 'open')
+      .map(cs => ({
+        ...cs,
+        stretch: stretches.find(s => s.id === cs.stretchId)
+      })) || []
   const closedCohortStretches =
     thisCohortStretches
       .filter(cohortStretches => cohortStretches.status === 'closed')
@@ -52,21 +59,6 @@ const SingleCohortStretchTables = ({
         ...cs,
         stretch: stretches.find(s => s.id === cs.stretchId)
       })) || []
-
-  const openCohortStretchIds = openCohortStretches.map(
-    stretch => stretch.stretchId
-  )
-  //const scheduledCohortStretchIds = scheduledCohortStretches.map(
-  //  stretch => stretch.stretchId
-  //)
-
-  const openStretches = stretches.filter(stretch =>
-    openCohortStretchIds.includes(stretch.id)
-  )
-
-  //const scheduledStretches = stretches.filter(stretch =>
-  //  scheduledCohortStretchIds.includes(stretch.id)
-  // )
 
   // StretchScheduler modal event handlers
   const handleRescheduleModalClose = () => setRescheduleModalOpen(false)
@@ -124,9 +116,10 @@ const SingleCohortStretchTables = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {openStretches.map(stretch => {
+          {openCohortStretches.map(cohortStretch => {
+            const { id, stretch } = cohortStretch
             return (
-              <TableRow key={stretch.id}>
+              <TableRow key={id}>
                 <TableCell>
                   <Link to={`/admin/singleStretch/${stretch.id}`}>
                     {stretch.title}

--- a/client/Components/SingleCohort/SubmittedStretches.js
+++ b/client/Components/SingleCohort/SubmittedStretches.js
@@ -50,7 +50,9 @@ const SubmittedStretches = ({
             )
             return (
               <Typography key={answer.id}>
-                <Link to={`admin/stretchAnswer/${answer.id}`}>
+                <Link
+                  to={`/admin/stretchAnswer/${answer.id}/student/${student.id}`}
+                >
                   <li>Submission for {stretchName.title}</li>
                 </Link>
               </Typography>

--- a/client/Components/SingleStretch/Controls.js
+++ b/client/Components/SingleStretch/Controls.js
@@ -1,11 +1,12 @@
 import React from 'react'
+import { connect } from 'react-redux'
 
 import Button from '@material-ui/core/Button'
 
 import { ControlStyles as styles } from './styles'
 
 const Controls = props => {
-  const { mode, changeMode } = props
+  const { mode, changeMode, authorId, userDetails } = props
 
   const setModeToUpdate = () => changeMode('update')
 
@@ -17,6 +18,7 @@ const Controls = props => {
           variant="contained"
           style={{ ...styles.updateButton }}
           onClick={setModeToUpdate}
+          disabled={authorId !== userDetails.id}
         >
           Update
         </Button>
@@ -32,4 +34,6 @@ const Controls = props => {
   )
 }
 
-export default Controls
+const mapStateToProps = ({ userDetails }) => ({ userDetails })
+
+export default connect(mapStateToProps)(Controls)

--- a/client/Components/SingleStretch/GeneralInfo.js
+++ b/client/Components/SingleStretch/GeneralInfo.js
@@ -15,7 +15,14 @@ import { GeneralInfoStyles as styles } from './styles'
 
 const GeneralInfo = props => {
   const { attributes, handleChange } = props
-  const { mode, title, categoryName, categoryId, difficulty } = attributes
+  const {
+    mode,
+    title,
+    categoryName,
+    categoryId,
+    difficulty,
+    minutes
+  } = attributes
 
   const handleDifficultyChange = (event, value) =>
     handleChange({ target: { name: 'difficulty', value } })
@@ -54,6 +61,21 @@ const GeneralInfo = props => {
                   <CategorySelect
                     categoryId={categoryId}
                     handleChange={handleChange}
+                  />
+                )}
+              </div>
+
+              {/* Minutes input/display */}
+              <div>
+                <InputLabel shrink>Minutes</InputLabel>
+                {mode === 'read' ? (
+                  <Typography variant="subtitle2">{minutes}</Typography>
+                ) : (
+                  <TextField
+                    name="minutes"
+                    defaultValue={minutes}
+                    margin="normal"
+                    onChange={handleChange}
                   />
                 )}
               </div>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -27,6 +27,7 @@ class SingleStretch extends Component {
     codePrompt: '// This is an example code prompt.',
     difficulty: 3,
     minutes: '',
+    authorId: '',
     isLoaded: false
   }
 
@@ -99,13 +100,17 @@ class SingleStretch extends Component {
     const { state } = this
     const { handleSubmit, changeMode } = this
     const { handleChange } = this
-    const { mode } = state
+    const { mode, authorId } = state
     return (
       <form onSubmit={handleSubmit}>
         <div style={styles.root}>
           <Grid container spacing={2} style={styles.sub}>
             <Grid item xs={12}>
-              <Controls mode={mode} changeMode={changeMode} />
+              <Controls
+                mode={mode}
+                changeMode={changeMode}
+                authorId={authorId}
+              />
             </Grid>
 
             <Grid item xs={12}>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -26,6 +26,7 @@ class SingleStretch extends Component {
     textPrompt: 'This is an example text prompt.',
     codePrompt: '// This is an example code prompt.',
     difficulty: 3,
+    minutes: '',
     isLoaded: false
   }
 

--- a/client/Components/StudentClosedStretchView/CodeSection.js
+++ b/client/Components/StudentClosedStretchView/CodeSection.js
@@ -45,10 +45,10 @@ class CodeSection extends Component {
               value={solution}
               onChange={handleChange}
             >
-              {solutions.map(el => {
+              {solutions.map((el, idnx) => {
                 const { dropdownTitle } = el
                 return (
-                  <MenuItem key={dropdownTitle} value={el.solution}>
+                  <MenuItem key={idnx} value={el.solution}>
                     {dropdownTitle}
                   </MenuItem>
                 )

--- a/client/Components/StudentClosedStretchView/GeneralInfo.js
+++ b/client/Components/StudentClosedStretchView/GeneralInfo.js
@@ -16,9 +16,8 @@ const GeneralInfo = ({ stretchMetaData }) => {
     { field: 'Title', dbColumn: 'title' },
     { field: 'Category', dbColumn: 'categoryName' },
     { field: 'Difficulty (out of 5)', dbColumn: 'difficulty' },
-    { field: 'Correct', dbColumn: 'isSolved' },
     { field: 'Rating (out of 5)', dbColumn: 'rating' },
-    { field: 'Time Took To Complete', dbColumn: 'timeToSolve' }
+    { field: 'Time Took To Complete', dbColumn: 'timeToSolveString' }
   ].reduce((acc, field) => {
     acc.push({ name: field.field, value: stretchMetaData[field.dbColumn] })
     return acc

--- a/client/Components/StudentClosedStretchView/GeneralInfo.js
+++ b/client/Components/StudentClosedStretchView/GeneralInfo.js
@@ -8,7 +8,7 @@ import InputLabel from '@material-ui/core/InputLabel'
 import { GeneralInfoStyles as styles } from '../SingleStretch/styles'
 import { useStyles } from './styles'
 
-const GeneralInfo = ({ stretchMetaData }) => {
+const GeneralInfo = ({ stretchMetaData, studentName }) => {
   const { info } = styles
   const { bottomMargin } = useStyles()
   const { scheduledDate, cohortName } = stretchMetaData
@@ -26,7 +26,8 @@ const GeneralInfo = ({ stretchMetaData }) => {
     <div>
       <Typography variant="subtitle2" className={bottomMargin}>
         <i>
-          You completed this stretch on {scheduledDate} in {cohortName}
+          {`${studentName ||
+            'You'} completed this stretch on ${scheduledDate} in ${cohortName}`}
         </i>
       </Typography>
       <ExpansionPanel styles={info}>

--- a/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
+++ b/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
@@ -15,15 +15,18 @@ import { useStyles } from './styles'
 
 const StudentClosedStretchView = ({
   stretchAnswerId,
+  studentName,
   getCommentsOfStretchAnswer,
   stretchAnswer,
   allStretchAnswerRelatedData
 }) => {
   const { textPromptSpacing, textPromptHeading } = useStyles()
   useEffect(() => {
-    getCommentsOfStretchAnswer(stretchAnswerId)
+    if (stretchAnswerId) {
+      getCommentsOfStretchAnswer(stretchAnswerId)
+    }
   }, [stretchAnswerId])
-  if (!allStretchAnswerRelatedData.stretchCode) {
+  if (!stretchAnswerId) {
     return <div>no stretch answer</div>
   }
   const { root } = styles
@@ -33,7 +36,10 @@ const StudentClosedStretchView = ({
   } = allStretchAnswerRelatedData
   return (
     <div styles={root}>
-      <GeneralInfo stretchMetaData={stretchMetaData} />
+      <GeneralInfo
+        stretchMetaData={stretchMetaData}
+        studentName={studentName}
+      />
       <Grid container justify="center" spacing={2}>
         <Grid item xs={12}>
           <Typography variant="subtitle2" className={textPromptHeading}>
@@ -53,22 +59,28 @@ const StudentClosedStretchView = ({
 }
 
 const mapStateToProps = (
-  { stretchAnswers, stretches, cohortStretches },
+  { stretchAnswers, stretches, cohortStretches, users },
   {
     match: {
-      params: { stretchAnswerId }
+      params: { stretchAnswerId, studentId }
     }
   }
 ) => {
+  let studentName = ''
   const stretchAnswer = stretchAnswers.find(sa => sa.id === stretchAnswerId)
-  const data = [stretchAnswer, stretches, cohortStretches]
-  const allStretchAnswerRelatedData = checkIfAllDataExists(...data)
-    ? getStretchAnswerMetaData(...data)
-    : {}
+  const data = [stretchAnswer, stretches, cohortStretches, users]
+  if (!checkIfAllDataExists(...data)) return {}
+  const allStretchAnswerRelatedData = getStretchAnswerMetaData(...data)
+  if (studentId) {
+    const student = users.find(u => u.id === studentId)
+    studentName = `${student.firstName} ${student.lastName}`
+  }
+
   return {
     stretchAnswerId,
     stretchAnswer,
-    allStretchAnswerRelatedData
+    allStretchAnswerRelatedData,
+    studentName
   }
 }
 

--- a/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
+++ b/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
@@ -21,10 +21,8 @@ const StudentClosedStretchView = ({
 }) => {
   const { textPromptSpacing, textPromptHeading } = useStyles()
   useEffect(() => {
-    if (stretchAnswerId) {
-      getCommentsOfStretchAnswer(stretchAnswerId)
-    }
-  }, [stretchAnswer])
+    getCommentsOfStretchAnswer(stretchAnswerId)
+  }, [stretchAnswerId])
   if (!allStretchAnswerRelatedData.stretchCode) {
     return <div>no stretch answer</div>
   }

--- a/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
+++ b/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
@@ -1,10 +1,8 @@
 import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { getCommentsOfStretchAnswerThunk } from '../../store/comments/actions'
-import {
-  getStretchAnswerMetaData,
-  checkIfAllDataExists
-} from './helperfunctions'
+import { getStretchAnswerMetaData } from './helperfunctions'
+import { checkIfAllDataExists } from '../../utilityfunctions'
 
 import GeneralInfo from './GeneralInfo'
 import CodeSection from './CodeSection'
@@ -57,7 +55,7 @@ const StudentClosedStretchView = ({
 }
 
 const mapStateToProps = (
-  { stretchAnswers, stretches, cohortStretches, cohorts, cohortUsers },
+  { stretchAnswers, stretches, cohortStretches },
   {
     match: {
       params: { stretchAnswerId }
@@ -65,7 +63,7 @@ const mapStateToProps = (
   }
 ) => {
   const stretchAnswer = stretchAnswers.find(sa => sa.id === stretchAnswerId)
-  const data = [stretchAnswer, stretches, cohortStretches, cohorts, cohortUsers]
+  const data = [stretchAnswer, stretches, cohortStretches]
   const allStretchAnswerRelatedData = checkIfAllDataExists(...data)
     ? getStretchAnswerMetaData(...data)
     : {}

--- a/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
+++ b/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
@@ -64,7 +64,6 @@ const mapStateToProps = (
     }
   }
 ) => {
-  console.log('here')
   const stretchAnswer = stretchAnswers.find(sa => sa.id === stretchAnswerId)
   const data = [stretchAnswer, stretches, cohortStretches, cohorts, cohortUsers]
   const allStretchAnswerRelatedData = checkIfAllDataExists(...data)

--- a/client/Components/StudentClosedStretchView/helperfunctions.js
+++ b/client/Components/StudentClosedStretchView/helperfunctions.js
@@ -21,8 +21,6 @@ export const getStretchAnswerMetaData = (
       return { ...cs, cohortName: name }
     })
 
-  console.log(selectedCohortStretches)
-  console.log(cohortId)
   const { scheduledDate } = selectedCohortStretches.find(
     cs => cs.cohortId === cohortId
   )

--- a/client/Components/StudentController/StudentController.js
+++ b/client/Components/StudentController/StudentController.js
@@ -10,18 +10,7 @@ const StudentController = () => {
   return (
     <Fragment>
       {/* path to go to student's home view */}
-      {/* <Route path="/student" exact component={StudentHomeView} /> */}
-
-      {/*
-          The below route is for testing purposes only.
-          Please delete this after the issue regarding the Login view redirecting
-          a user to /student after successfully logging in or signing up has been resolved.
-      */}
-      <Route
-        path="/student"
-        exact
-        render={() => <div>student home view</div>}
-      />
+      <Route path="/student" exact component={StudentHomeView} />
 
       {/* path to go to student's home view */}
       <Route
@@ -32,7 +21,7 @@ const StudentController = () => {
 
       {/* path to go to view to complete stretch currently open */}
       <Route
-        path="/student/stretch/:stretchId"
+        path="/student/stretch/:cohortStretchId"
         exact
         component={OpenStretchView}
       />

--- a/client/Components/StudentHomeView/StretchListView.js
+++ b/client/Components/StudentHomeView/StretchListView.js
@@ -21,8 +21,13 @@ const useStyles = makeStyles(theme => ({
 
 function StretchListView(props) {
   const classes = useStyles()
-  function createOpenStretchData(id, title, categoryName, difficulty) {
-    return { id, title, categoryName, difficulty }
+  function createOpenStretchData(
+    cohortStretchId,
+    title,
+    categoryName,
+    difficulty
+  ) {
+    return { cohortStretchId, title, categoryName, difficulty }
   }
   function createSubmittedStretchData(
     stretchAnswerId,
@@ -33,20 +38,20 @@ function StretchListView(props) {
   ) {
     return { stretchAnswerId, title, isSolved, rating, stretchId }
   }
-
+  console.log(props)
   const rows = []
   if (props.openStretches) {
     for (let i = 0; i < props.openStretches.length; ++i) {
       rows.push(
         createOpenStretchData(
-          props.openStretches[i].id,
+          props.openStretches[i].cohortStretchId,
           props.openStretches[i].title,
           props.openStretches[i].categoryName,
           props.openStretches[i].difficulty
         )
       )
     }
-  } else {
+  } else if (props.submittedStretches) {
     for (let i = 0; i < props.submittedStretches.length; ++i) {
       rows.push(
         createSubmittedStretchData(
@@ -74,7 +79,9 @@ function StretchListView(props) {
             {rows.map((row, indx) => (
               <TableRow key={indx}>
                 <TableCell component="th" scope="row">
-                  <Link to={`/student/stretch/${row.id}`}>{row.title}</Link>
+                  <Link to={`/student/stretch/${row.cohortStretchId}`}>
+                    {row.title}
+                  </Link>
                 </TableCell>
                 <TableCell align="right">{row.categoryName}</TableCell>
                 <TableCell align="right">{row.difficulty}</TableCell>

--- a/client/Components/StudentHomeView/StretchListView.js
+++ b/client/Components/StudentHomeView/StretchListView.js
@@ -32,13 +32,13 @@ function StretchListView(props) {
   function createSubmittedStretchData(
     stretchAnswerId,
     title,
-    isSolved,
+    cohortName,
     rating,
     stretchId
   ) {
-    return { stretchAnswerId, title, isSolved, rating, stretchId }
+    return { stretchAnswerId, title, cohortName, rating, stretchId }
   }
-  console.log(props)
+
   const rows = []
   if (props.openStretches) {
     for (let i = 0; i < props.openStretches.length; ++i) {
@@ -57,7 +57,7 @@ function StretchListView(props) {
         createSubmittedStretchData(
           props.submittedStretches[i].id,
           props.submittedStretches[i].title,
-          props.submittedStretches[i].isSolved,
+          props.submittedStretches[i].cohortName,
           props.submittedStretches[i].rating,
           props.submittedStretches[i].stretchId
         )
@@ -94,8 +94,8 @@ function StretchListView(props) {
           <TableHead>
             <TableRow>
               <TableCell>Title</TableCell>
-              <TableCell align="right">Status</TableCell>
               <TableCell align="right">Rating</TableCell>
+              <TableCell align="right">Cohort</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -106,10 +106,9 @@ function StretchListView(props) {
                     {row.title}
                   </Link>
                 </TableCell>
-                <TableCell align="right">
-                  {row.isSolved ? 'submitted' : 'not submitted'}
-                </TableCell>
+
                 <TableCell align="right">{row.rating}</TableCell>
+                <TableCell align="right">{row.cohortName}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/client/Components/StudentHomeView/StudentHomeView.js
+++ b/client/Components/StudentHomeView/StudentHomeView.js
@@ -38,8 +38,8 @@ const mapStateToProps = ({
     })
 
   const submittedStretches = stretchAnswers.map(sa => {
-    const { title } = stretches.find(s => s.id === sa.stretchId)
-    return { ...sa, title }
+    const { title, id } = stretches.find(s => s.id === sa.stretchId)
+    return { ...sa, title, stretchId: id }
   })
 
   return {

--- a/client/Components/StudentHomeView/StudentHomeView.js
+++ b/client/Components/StudentHomeView/StudentHomeView.js
@@ -1,10 +1,8 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import StretchListView from './StretchListView'
 import { checkIfAllDataExists } from '../../utilityfunctions'
-import { getStretchAnswersOfStudentThunk } from '../../store/stretch-answers/actions'
-import { getStudentCohortUsersThunk } from '../../store/cohort-users/actions'
 
 const mapStateToProps = ({
   userDetails,
@@ -51,17 +49,6 @@ const mapStateToProps = ({
   }
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    loadStudentRelatedData: studentId => {
-      return Promise.all([
-        dispatch(getStretchAnswersOfStudentThunk(studentId)),
-        dispatch(getStudentCohortUsersThunk(studentId))
-      ])
-    }
-  }
-}
-
 const useStyles = makeStyles(theme => ({
   content: {
     flexGrow: 1,
@@ -75,16 +62,9 @@ const StudentHomeView = ({
   submittedStretches,
   match: {
     params: { status }
-  },
-  loadStudentRelatedData,
-  userDetails
+  }
 }) => {
   const classes = useStyles()
-  /*useEffect(() => {
-    if (userDetails.id) {
-      loadStudentRelatedData(userDetails.id)
-    }
-  }, [userDetails])*/
 
   return (
     <main className={classes.content}>
@@ -99,7 +79,4 @@ const StudentHomeView = ({
   )
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(StudentHomeView)
+export default connect(mapStateToProps)(StudentHomeView)

--- a/client/Components/StudentSidebar/StudentSidebar.js
+++ b/client/Components/StudentSidebar/StudentSidebar.js
@@ -37,7 +37,7 @@ const StudentSidebar = ({ history, location: { pathname } }) => {
       </List>
       <Divider />
       <List>
-        {['Account Information', 'Logout'].map(text => (
+        {['Account Information'].map(text => (
           <ListItem button key={text}>
             <ListItemText primary={text} />
           </ListItem>

--- a/client/Components/_shared/CohortSelect.js
+++ b/client/Components/_shared/CohortSelect.js
@@ -37,14 +37,14 @@ CohortSelect.defaultProps = {
   handleChange: () => {}
 }
 
-const mapStateToProps = state => {
-  const { userDetails, cohorts, cohortUsers } = state
+const mapStateToProps = ({ cohorts }) => ({ cohorts })
+// const { userDetails, cohorts, cohortUsers } = state
 
-  const userCohorts = cohortUsers
-    .filter(e => e.userId === userDetails.id) // Find all cohorts associated to user
-    .map(e => cohorts.find(cohort => cohort.id === e.cohortId)) // Associate cohort details to UserCohort
+// const userCohorts = cohortUsers
+//   .filter(e => e.userId === userDetails.id) // Find all cohorts associated to user
+//   .map(e => cohorts.find(cohort => cohort.id === e.cohortId)) // Associate cohort details to UserCohort
 
-  return { cohorts: userCohorts }
-}
+// return { cohorts: userCohorts }
+//}
 
 export default connect(mapStateToProps)(CohortSelect)

--- a/client/Components/_shared/StretchScheduler.js
+++ b/client/Components/_shared/StretchScheduler.js
@@ -10,6 +10,8 @@ import Grid from '@material-ui/core/Grid'
 import Modal from '@material-ui/core/Modal'
 import Paper from '@material-ui/core/Paper'
 import Button from '@material-ui/core/Button'
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 
 import DateAndTimePicker from './DateAndTimePicker'
 import CohortSelect from './CohortSelect'
@@ -20,6 +22,7 @@ const StretchScheduler = props => {
 
   const [scheduledDate, setScheduledDate] = useState(new Date())
   const [selectedCohortId, setSelectedCohortId] = useState('')
+  const [allowAnswersToBeRun, setAllowAnswersToBeRun] = useState(false)
 
   const handleCohortIdChange = event => setSelectedCohortId(event.target.value)
 
@@ -30,8 +33,7 @@ const StretchScheduler = props => {
       return props.scheduleStretch({
         status: 'scheduled',
         scheduledDate,
-        minutes: 5,
-        allowAnswersToBeRun: false,
+        allowAnswersToBeRun,
         stretchId: id,
         cohortId: selectedCohortId
       })
@@ -73,6 +75,24 @@ const StretchScheduler = props => {
                 <CohortSelect
                   cohortId={selectedCohortId}
                   handleChange={handleCohortIdChange}
+                />
+              </Grid>
+            )}
+
+            <Grid item xs={12} style={{ height: '20px' }} />
+            {mode === 'create' && (
+              <Grid item xs={12} style={styles.center}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={allowAnswersToBeRun}
+                      onChange={({ target }) =>
+                        setAllowAnswersToBeRun(target.checked)
+                      }
+                      color="primary"
+                    />
+                  }
+                  label="Check this box if you want to allow students to run code while completing the stretch"
                 />
               </Grid>
             )}

--- a/client/store/auth/actions.js
+++ b/client/store/auth/actions.js
@@ -27,13 +27,15 @@ export const login = credentials => {
   }
 }
 
-export const checkIfUserLoggedInThunk = history => {
+export const checkIfUserLoggedInThunk = () => {
   return dispatch => {
     return axios
       .get('/api/auth')
       .then(res => res.data)
       .then(user => dispatch(getUser(user)))
-      .catch(() => history.push('/'))
+      .catch(() => {
+        window.location.hash = '/'
+      })
   }
 }
 
@@ -41,7 +43,7 @@ export const logoutUserThunk = history => {
   return dispatch => {
     return axios
       .delete('/api/auth')
-      .then(() => history.push('/'))
       .then(() => dispatch(logutUser()))
+      .then(() => history.push('/'))
   }
 }

--- a/client/store/auth/actions.js
+++ b/client/store/auth/actions.js
@@ -37,8 +37,11 @@ export const checkIfUserLoggedInThunk = history => {
   }
 }
 
-export const logoutUserThunk = () => {
+export const logoutUserThunk = history => {
   return dispatch => {
-    return axios.delete('/api/auth').then(() => dispatch(logutUser()))
+    return axios
+      .delete('/api/auth')
+      .then(() => history.push('/'))
+      .then(() => dispatch(logutUser()))
   }
 }

--- a/client/store/auth/actions.js
+++ b/client/store/auth/actions.js
@@ -27,12 +27,13 @@ export const login = credentials => {
   }
 }
 
-export const checkIfUserLoggedInThunk = () => {
+export const checkIfUserLoggedInThunk = history => {
   return dispatch => {
     return axios
       .get('/api/auth')
       .then(res => res.data)
       .then(user => dispatch(getUser(user)))
+      .catch(() => history.push('/'))
   }
 }
 

--- a/client/store/cohort-users/actions.js
+++ b/client/store/cohort-users/actions.js
@@ -25,3 +25,10 @@ export const getAllCohortUsers = () => dispatch => {
     .get('/api/cohort-users')
     .then(res => dispatch(getCohortUsers(res.data)))
 }
+
+// GET all cohoort users of student
+export const getStudentCohortUsersThunk = studentId => dispatch => {
+  return axios
+    .get(`/api/cohort-users/student/${studentId}`)
+    .then(res => dispatch(getCohortUsers(res.data)))
+}

--- a/client/store/stretch-answers/actions.js
+++ b/client/store/stretch-answers/actions.js
@@ -47,6 +47,12 @@ export const getStretchAnswersOfSingleAdminThunk = adminId => dispatch => {
     .then(res => dispatch(getStretchAnswers(res.data)))
 }
 
+export const getStretchAnswersOfStudentThunk = studentId => dispatch => {
+  return axios
+    .get(`/api/stretch-answers/student/${studentId}`)
+    .then(res => dispatch(getStretchAnswers(res.data)))
+}
+
 export const createStretchAnswerThunk = newStretchAnswer => dispatch => {
   return axios
     .post(`/api/stretch-answers/create`, { newStretchAnswer })

--- a/client/utilityfunctions.js
+++ b/client/utilityfunctions.js
@@ -1,6 +1,8 @@
 export const checkIfAllDataExists = (...args) => {
   for (let i = 0; i < args.length; ++i) {
-    if (Array.isArray(args[i])) {
+    if (!args[i]) {
+      return false
+    } else if (Array.isArray(args[i])) {
       if (!args[i].length) return false
     } else if (!args[i].id) {
       return false

--- a/server/api/cohort-users.js
+++ b/server/api/cohort-users.js
@@ -10,4 +10,11 @@ router.get('/', (req, res, next) => {
     .catch(next)
 })
 
+// GET, retrieves all cohort users of student
+router.get('/student/:studentId', (req, res, next) => {
+  CohortUser.findAll({ where: { userId: req.params.studentId } })
+    .then(cohortUsers => res.json(cohortUsers))
+    .catch(next)
+})
+
 module.exports = router

--- a/server/api/stretch-answers.js
+++ b/server/api/stretch-answers.js
@@ -17,9 +17,17 @@ router.get('/admin/:adminId', (req, res, next) => {
     .catch(next)
 })
 
+// GET all StrecthAnswers of studentId
+router.get('/student/:studentId', (req, res, next) => {
+  StretchAnswer.getAnswersOfStudent(req.params.studentId)
+    .then(stretchAnswers => res.json(stretchAnswers))
+    .catch(next)
+})
+
 // POST student StretchAnswer
 router.post('/create', (req, res, next) => {
   StretchAnswer.create(req.body.newStretchAnswer)
+    .then(stretchAnswer => stretchAnswer.addAssociations())
     .then(stretchAnswer => res.json(stretchAnswer))
     .catch(next)
 })

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -10,12 +10,7 @@ const {
   CohortStretch
 } = require('./models')
 
-const {
-  UserMethods,
-  CohortMethods,
-  StretchAnswerMethods,
-  CommentMethods
-} = require('./methods')
+const { UserMethods, CohortMethods, CommentMethods } = require('./methods')
 
 function initDb(force = false) {
   return db.authenticate().then(() => {
@@ -66,8 +61,6 @@ function initDb(force = false) {
 
 User.getStudentsOfSingleAdmin = UserMethods.getStudentsOfSingleAdmin
 Cohort.getCohortsOfSingleAdmin = CohortMethods.getCohortsOfSingleAdmin
-StretchAnswer.getAnswersOfStudentsOfSingleAdmin =
-  StretchAnswerMethods.getAnswersOfStudentsOfSingleAdmin
 Comment.getCommentsOfStretchAnswer = CommentMethods.getCommentsOfStretchAnswer
 Comment.createNewComment = CommentMethods.createNewComment
 

--- a/server/db/methods/StretchAnswer.js
+++ b/server/db/methods/StretchAnswer.js
@@ -8,7 +8,6 @@ const getAnswersOfStudentsOfSingleAdmin = function(adminId) {
   })
     .then(user => user.cohortusers.map(cu => cu.cohortId))
     .then(cohortIds => {
-      console.log(cohortIds)
       return StretchAnswer.findAll({
         include: [
           {

--- a/server/db/methods/index.js
+++ b/server/db/methods/index.js
@@ -2,14 +2,14 @@ const UserMethods = require('./User')
 const StretchMethods = require('./Stretch')
 const CohortStretchMethods = require('./CohortStretch')
 const CohortMethods = require('./Cohort')
-const StretchAnswerMethods = require('./StretchAnswer')
 const CommentMethods = require('./Comment')
+const StretchAnswerMethods = require('./StretchAnswer')
 
 module.exports = {
   UserMethods,
   StretchMethods,
   CohortStretchMethods,
   CohortMethods,
-  StretchAnswerMethods,
-  CommentMethods
+  CommentMethods,
+  StretchAnswerMethods
 }

--- a/server/db/models/CohortStretch.js
+++ b/server/db/models/CohortStretch.js
@@ -24,14 +24,6 @@ const CohortStretch = db.define('cohortstretch', {
   solution: {
     type: db.Sequelize.TEXT
   },
-  minutes: {
-    type: db.Sequelize.INTEGER,
-    allowNull: false,
-    validate: {
-      notEmpty: true,
-      min: 1
-    }
-  },
   scheduledDate: {
     type: db.Sequelize.DATE,
     allowNull: false,

--- a/server/db/models/Stretch.js
+++ b/server/db/models/Stretch.js
@@ -30,6 +30,14 @@ const Stretch = db.define('stretch', {
       max: 5
     }
   },
+  minutes: {
+    type: db.Sequelize.INTEGER,
+    allowNull: false,
+    validate: {
+      notEmpty: true,
+      min: 1
+    }
+  },
   solution: {
     type: db.Sequelize.TEXT,
     defaultValue: `const solution = console.log('You did it!')`,


### PR DESCRIPTION
More cleaning up 

- Minutes is input when you create stretch now
- Whne shcedule stretch, there is checkbox for allowing students to run code when writing out answer or not
       - depnding on that value, open strethc view student is shown is different
      - open stretch view includes button to submit rather than just waiting for timer to finish
- only author stretch can edit it
- if you are not logged in, you can only view the home page, now the login page
        - if you try to load any other url, it changes it to base url
- when you click on student submitted strethc in admin view, it goes to thr student closed stretch view
        - dropdown to rank student answer coming
- changes on student side to accomodate stretchanswer association changing from stretch to cohortstretch

I also made decent number of changes in how the data is loaded and which data is loaded. I am seeing significant imporveent in the speed of the application. while some of it is definitely due to the seed file being much smaller, I do think the changes I made are having a difference. What I did as thus
- data only now loads when somebody is logged in, ie moved the data loading from App.js to FrameworkHOC.js
- when somebody logs in or loads a page logged in, a common set of the data for all the models gets loaded
- then data associated to the specific user also gets loaded, with the models/type of data that gets loaded dependent on whether the user is student or admin
- i realize this is decent change so happy to talk about it more/explain it in person and fix any screwups this causes