### PR TITLE
Small things

### DIFF
--- a/client/Components/AdminHomeView/helperfunctions.js
+++ b/client/Components/AdminHomeView/helperfunctions.js
@@ -26,9 +26,7 @@ export const getFilteredStretchesOfAdmin = (
   students,
   stretchAnswers
 ) => {
-  if (
-    !checkIfAllDataExists(cohortStretches, stretches, students, stretchAnswers)
-  ) {
+  if (!checkIfAllDataExists(cohortStretches, stretches, students)) {
     return { scheduled: [], open: [] }
   }
 

--- a/client/Components/AdminStretches/AdminStretches.js
+++ b/client/Components/AdminStretches/AdminStretches.js
@@ -10,10 +10,9 @@ import TableBody from '@material-ui/core/TableBody'
 import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
 import Button from '@material-ui/core/Button'
-
 import Card from '@material-ui/core/Card'
-
 import Typography from '@material-ui/core/Typography'
+import Tooltip from '@material-ui/core/Tooltip'
 
 import StretchScheduler from '../_shared/StretchScheduler'
 
@@ -130,8 +129,11 @@ class AdminStretches extends Component {
 
   render() {
     const { searchTerm } = this.state
-    const { stretches } = this.props
-    const currentStretches = this.state.currentStretches.length > 0 ? this.state.currentStretches : stretches
+    const { stretches, cohorts, cohortStretches } = this.props
+    const currentStretches =
+      this.state.currentStretches.length > 0
+        ? this.state.currentStretches
+        : stretches
 
     const allCategories = []
     stretches.map(stretch => allCategories.push(stretch.categoryName))
@@ -215,9 +217,7 @@ class AdminStretches extends Component {
 
             <Typography variant="h6">Filter by Author:</Typography>
             <form onSubmit={this.applyAuthorFilter}>
-              <select
-                onChange={this.selectAuthorFilter}
-              >
+              <select onChange={this.selectAuthorFilter}>
                 {authors.map((auth, index) => (
                   <option key={index} value={auth}>
                     {auth}
@@ -261,6 +261,12 @@ class AdminStretches extends Component {
             </TableHead>
             <TableBody>
               {currentStretches.map(stretch => {
+                const cohortsAlreadyUsedStretch = cohortStretches
+                  .filter(cs => cs.stretchId === stretch.id)
+                  .map(cs => cs.cohortId)
+                const disableButton = cohorts.every(c =>
+                  cohortsAlreadyUsedStretch.includes(c.id)
+                )
                 return (
                   <TableRow key={stretch.id}>
                     <TableCell>
@@ -272,12 +278,24 @@ class AdminStretches extends Component {
                     <TableCell>{stretch.categoryName}</TableCell>
                     <TableCell>{stretch.difficulty}</TableCell>
                     <TableCell>
-                      <Button
-                        color="secondary"
-                        onClick={() => handleModalOpen(stretch)}
+                      <Tooltip
+                        title={
+                          disableButton
+                            ? 'You have already used this stretch in all your cohorts'
+                            : ''
+                        }
+                        placement="top-end"
                       >
-                        Schedule
-                      </Button>
+                        <div>
+                          <Button
+                            color="secondary"
+                            onClick={() => handleModalOpen(stretch)}
+                            disabled={disableButton}
+                          >
+                            Schedule
+                          </Button>
+                        </div>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 )
@@ -290,18 +308,22 @@ class AdminStretches extends Component {
   }
 }
 
-const mapStateToProps = state => {
-  const { categories, stretches } = state
-  return {
-    categories,
-    stretches
-  }
-}
+const mapStateToProps = ({
+  categories,
+  stretches,
+  cohorts,
+  cohortStretches
+}) => ({
+  categories,
+  stretches,
+  cohorts,
+  cohortStretches
+})
 
 const mapDispatchToProps = dispatch => {
   return {
     fetchCategories: () => dispatch(getAllCategories()),
-    fetchStretches: () => dispatch(getAllStretches()),
+    fetchStretches: () => dispatch(getAllStretches())
   }
 }
 export default connect(

--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -46,7 +46,8 @@ const OpenStretchView = ({
   myStretch,
   myCohortStretch,
   createStretchAnswer,
-  userDetails
+  userDetails,
+  history
 }) => {
   const classes = useStyles()
   const [codePrompt, setCodePrompt] = useState('')
@@ -54,6 +55,15 @@ const OpenStretchView = ({
   const [displayMinutes, setDisplayMinutes] = useState(0)
   const [displaySeconds, setDisplaySeconds] = useState(59)
   const [stretchAnswer, setStretchAnswer] = useState('')
+
+  const submitStretch = () => {
+    return createStretchAnswer({
+      body: stretchAnswer,
+      timeToSolve: myStretch.minutes * 60 - remainingTime,
+      cohortstretchId: myCohortStretch.id,
+      userId: userDetails.id
+    }).then(() => history.push('/student/stretches/submitted'))
+  }
   useEffect(() => {
     if (myStretch) {
       setCodePrompt(myStretch.codePrompt)
@@ -75,12 +85,7 @@ const OpenStretchView = ({
       }, 1000)
       if (remainingTime === 1) {
         clearTimeout(timer)
-        createStretchAnswer({
-          body: stretchAnswer,
-          timeToSolve: myStretch.minutes * 60 - remainingTime,
-          cohortstretchId: myCohortStretch.id,
-          userId: userDetails.id
-        })
+        submitStretch()
       }
     }
   })
@@ -115,18 +120,7 @@ const OpenStretchView = ({
           />
         ))}
 
-      <Button
-        onClick={() =>
-          createStretchAnswer({
-            body: stretchAnswer,
-            timeToSolve: myStretch.minutes * 60 - remainingTime,
-            cohortstretchId: myCohortStretch.id,
-            userId: userDetails.id
-          })
-        }
-      >
-        Submit
-      </Button>
+      <Button onClick={submitStretch}>Submit</Button>
     </div>
   )
 }

--- a/client/Components/StretchReviewView/StretchReviewView.js
+++ b/client/Components/StretchReviewView/StretchReviewView.js
@@ -10,7 +10,7 @@ import { textPromptStyles } from './styles'
 
 const StretchReviewView = ({ attributes, currentCohortStretch }) => {
   if (!attributes) return <div>Data still loading</div>
-  const { textPrompt, ...otherStretchFields } = attributes
+  const { textPrompt, codePrompt, ...otherStretchFields } = attributes
 
   return (
     <div>
@@ -31,7 +31,9 @@ const StretchReviewView = ({ attributes, currentCohortStretch }) => {
           </Typography>
         </Grid>
         <Grid item xs={12}>
-          <CodeSection solution={currentCohortStretch.solution} />
+          <CodeSection
+            solution={`${codePrompt}\n\n${currentCohortStretch.solution}`}
+          />
         </Grid>
       </Grid>
     </div>

--- a/client/Components/StudentClosedStretchView/CodeSection.js
+++ b/client/Components/StudentClosedStretchView/CodeSection.js
@@ -27,7 +27,7 @@ class CodeSection extends Component {
   }
 
   render() {
-    const { studentAnswer, solutions } = this.props
+    const { studentAnswer, solutions, codePrompt } = this.props
     const { center, select, solutionSelect } = editorsStyles()
     const { editorTheme, solution } = this.state
     const { handleChange } = this
@@ -59,14 +59,14 @@ class CodeSection extends Component {
         <Grid container>
           <Grid item xs={6}>
             <SingleCodeComponent
-              savedCode={studentAnswer}
+              savedCode={`${codePrompt}\n\n${studentAnswer}`}
               editorId="student"
               {...{ editorTheme, handleChange }}
             />
           </Grid>
           <Grid item xs={6}>
             <SingleCodeComponent
-              savedCode={solution}
+              savedCode={`${codePrompt}\n\n${solution}`}
               editorId="admin"
               {...{ editorTheme, handleChange }}
             />

--- a/client/Components/StudentClosedStretchView/GeneralInfo.js
+++ b/client/Components/StudentClosedStretchView/GeneralInfo.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import StudentRanking from './StudentRanking'
 import Grid from '@material-ui/core/Grid'
 import ExpansionPanel from '@material-ui/core/ExpansionPanel'
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
@@ -11,7 +12,8 @@ import { useStyles } from './styles'
 const GeneralInfo = ({ stretchMetaData, studentName }) => {
   const { info } = styles
   const { bottomMargin } = useStyles()
-  const { scheduledDate, cohortName } = stretchMetaData
+  const [answerRating, setAnswerRating] = useState(0)
+  const { scheduledDate, cohortName, stretchAnswerId } = stretchMetaData
   const selectedFields = [
     { field: 'Title', dbColumn: 'title' },
     { field: 'Category', dbColumn: 'categoryName' },
@@ -24,12 +26,18 @@ const GeneralInfo = ({ stretchMetaData, studentName }) => {
   }, [])
   return (
     <div>
-      <Typography variant="subtitle2" className={bottomMargin}>
+      <Typography variant="subtitle2">
         <i>
           {`${studentName ||
             'You'} completed this stretch on ${scheduledDate} in ${cohortName}`}
         </i>
       </Typography>
+      {studentName && stretchMetaData.rating === 'N/A' && (
+        <StudentRanking
+          {...{ stretchAnswerId, answerRating, setAnswerRating }}
+        />
+      )}
+      <div className={bottomMargin} />
       <ExpansionPanel styles={info}>
         <ExpansionPanelSummary>
           <Grid container justify="center" alignItems="center" spacing={2}>

--- a/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
+++ b/client/Components/StudentClosedStretchView/StudentClosedStretchView.js
@@ -32,7 +32,7 @@ const StudentClosedStretchView = ({
   const { root } = styles
   const {
     stretchMetaData,
-    stretchCode: { textPrompt, studentAnswer, solutions },
+    stretchCode: { textPrompt, codePrompt, studentAnswer, solutions },
     relatedUsers
   } = allStretchAnswerRelatedData
   return (
@@ -53,7 +53,7 @@ const StudentClosedStretchView = ({
           </Typography>
         </Grid>
       </Grid>
-      <CodeSection {...{ studentAnswer, solutions }} />
+      <CodeSection {...{ studentAnswer, codePrompt, solutions }} />
       <CommentsSection
         stretchAnswer={stretchAnswer}
         relatedUsers={relatedUsers}

--- a/client/Components/StudentClosedStretchView/StudentRanking.js
+++ b/client/Components/StudentClosedStretchView/StudentRanking.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import Button from '@material-ui/core/Button'
+import { updateStretchAnswerThunk } from '../../store/stretch-answers/actions'
+import { useStyles } from './styles'
+
+const StudentRanking = ({
+  stretchAnswerId,
+  answerRating,
+  setAnswerRating,
+  updateStretchAnswer
+}) => {
+  const { starColor } = useStyles()
+  return (
+    <div>
+      {[1, 2, 3, 4, 5].map(el => {
+        return (
+          <i
+            key={el}
+            className={`fa${
+              el <= answerRating ? 's' : 'r'
+            } fa-star ${starColor}`}
+            onClick={() => setAnswerRating(el)}
+          />
+        )
+      })}
+      <Button
+        type="button"
+        color="primary"
+        size="small"
+        onClick={() =>
+          updateStretchAnswer(stretchAnswerId, { rating: answerRating })
+        }
+      >
+        Submit rating
+      </Button>
+    </div>
+  )
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    updateStretchAnswer: (stretchAnswerId, updatedFields) =>
+      dispatch(updateStretchAnswerThunk(stretchAnswerId, updatedFields))
+  }
+}
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(StudentRanking)

--- a/client/Components/StudentClosedStretchView/helperfunctions.js
+++ b/client/Components/StudentClosedStretchView/helperfunctions.js
@@ -7,6 +7,7 @@ export const getStretchAnswerMetaData = (
   userDetails
 ) => {
   const {
+    id,
     cohortstretchId,
     body,
     rating,
@@ -39,6 +40,7 @@ export const getStretchAnswerMetaData = (
     })
 
   const stretchMetaData = {
+    stretchAnswerId: id,
     cohortName,
     categoryName: categoryName || 'N/A',
     difficulty: difficulty || 'N/A',

--- a/client/Components/StudentClosedStretchView/helperfunctions.js
+++ b/client/Components/StudentClosedStretchView/helperfunctions.js
@@ -21,9 +21,13 @@ export const getStretchAnswerMetaData = (
   const { stretchId, scheduledDate, adminIds } = cohortStretches.find(
     cs => cs.id === cohortstretchId
   )
-  const { categoryName, difficulty, title, textPrompt } = stretches.find(
-    s => s.id === stretchId
-  )
+  const {
+    categoryName,
+    difficulty,
+    title,
+    textPrompt,
+    codePrompt
+  } = stretches.find(s => s.id === stretchId)
 
   const solutions = cohortStretches
     .filter(cs => cs.stretchId === stretchId)
@@ -57,6 +61,7 @@ export const getStretchAnswerMetaData = (
 
   const stretchCode = {
     textPrompt,
+    codePrompt,
     studentAnswer: body,
     solutions
   }

--- a/client/Components/StudentClosedStretchView/styles.js
+++ b/client/Components/StudentClosedStretchView/styles.js
@@ -41,6 +41,9 @@ const useStyles = makeStyles(theme => {
     bottomMargin: {
       marginBottom: '15px',
       fontSize: '1rem'
+    },
+    starColor: {
+      color
     }
   }
 })

--- a/client/Components/StudentHomeView/StudentHomeView.js
+++ b/client/Components/StudentHomeView/StudentHomeView.js
@@ -22,9 +22,15 @@ const mapStateToProps = ({
   )
     return { userDetails }
   const studentCohorts = cohortUsers.map(cu => cu.cohortId)
+  const cohortStretchIds = stretchAnswers.map(sa => sa.cohortstretchId)
 
   const openStretches = cohortStretches
-    .filter(cs => studentCohorts.includes(cs.cohortId) && cs.status === 'open')
+    .filter(
+      cs =>
+        studentCohorts.includes(cs.cohortId) &&
+        !cohortStretchIds.includes(cs.id) &&
+        cs.status === 'open'
+    )
     .map(cs => {
       const stretch = stretches.find(s => s.id === cs.stretchId)
       const { id, ...stretchFields } = stretch

--- a/client/Components/_shared/CohortSelect.js
+++ b/client/Components/_shared/CohortSelect.js
@@ -7,7 +7,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import InputLabel from '@material-ui/core/InputLabel'
 
 const CohortSelect = props => {
-  const { style, cohorts, cohortId } = props
+  const { style, cohorts, cohortId, stretchId } = props
   const { handleChange } = props
 
   return (
@@ -37,14 +37,13 @@ CohortSelect.defaultProps = {
   handleChange: () => {}
 }
 
-const mapStateToProps = ({ cohorts }) => ({ cohorts })
-// const { userDetails, cohorts, cohortUsers } = state
-
-// const userCohorts = cohortUsers
-//   .filter(e => e.userId === userDetails.id) // Find all cohorts associated to user
-//   .map(e => cohorts.find(cohort => cohort.id === e.cohortId)) // Associate cohort details to UserCohort
-
-// return { cohorts: userCohorts }
-//}
+const mapStateToProps = ({ cohorts, cohortStretches }, { stretchId }) => {
+  const cohortsAlreadyUsedStretch = cohortStretches
+    .filter(cs => cs.stretchId === stretchId)
+    .map(cs => cs.cohortId)
+  return {
+    cohorts: cohorts.filter(c => !cohortsAlreadyUsedStretch.includes(c.id))
+  }
+}
 
 export default connect(mapStateToProps)(CohortSelect)

--- a/client/Components/_shared/StretchScheduler.js
+++ b/client/Components/_shared/StretchScheduler.js
@@ -75,6 +75,7 @@ const StretchScheduler = props => {
                 <CohortSelect
                   cohortId={selectedCohortId}
                   handleChange={handleCohortIdChange}
+                  stretchId={id}
                 />
               </Grid>
             )}

--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,13 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
     />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.8.1/css/all.css"
+      integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+      crossorigin="anonymous"
+    />
+
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.4/ace.js"
       type="text/javascript"

--- a/client/store/stretch-answers/actions.js
+++ b/client/store/stretch-answers/actions.js
@@ -21,8 +21,9 @@ const createStretchAnswer = newStretchAnswer => ({
   newStretchAnswer
 })
 
-const replaceStretchAnswer = updatedStretchAnswer => ({
+const replaceStretchAnswer = (stretchAnswerId, updatedStretchAnswer) => ({
   type: UPDATE_STRETCH_ANSWER,
+  stretchAnswerId,
   updatedStretchAnswer
 })
 
@@ -58,4 +59,15 @@ export const createStretchAnswerThunk = newStretchAnswer => dispatch => {
     .post(`/api/stretch-answers/create`, { newStretchAnswer })
     .then(res => res.data)
     .then(stretchAnswer => dispatch(createStretchAnswer(stretchAnswer)))
+}
+
+export const updateStretchAnswerThunk = (stretchAnswerId, updatedFields) => {
+  return dispatch => {
+    return axios
+      .put(`/api/stretch-answers/${stretchAnswerId}`, updatedFields)
+      .then(res => res.data)
+      .then(stretchAnswer =>
+        dispatch(replaceStretchAnswer(stretchAnswerId, stretchAnswer))
+      )
+  }
 }

--- a/client/store/stretch-answers/reducer.js
+++ b/client/store/stretch-answers/reducer.js
@@ -1,4 +1,8 @@
-import { GET_STRETCH_ANSWERS, CREATE_STRETCH_ANSWER } from './actions'
+import {
+  GET_STRETCH_ANSWERS,
+  CREATE_STRETCH_ANSWER,
+  UPDATE_STRETCH_ANSWER
+} from './actions'
 
 export default (state = [], action) => {
   switch (action.type) {
@@ -6,6 +10,10 @@ export default (state = [], action) => {
       return [...action.stretchAnswers]
     case CREATE_STRETCH_ANSWER:
       return [...state, action.newStretchAnswer]
+    case UPDATE_STRETCH_ANSWER:
+      return state.map(sa =>
+        sa.id === action.stretchAnswerId ? action.updatedStretchAnswer : sa
+      )
     default:
       return state
   }

--- a/client/utilityfunctions.js
+++ b/client/utilityfunctions.js
@@ -1,5 +1,6 @@
 export const checkIfAllDataExists = (...args) => {
   for (let i = 0; i < args.length; ++i) {
+    console.log(args[i])
     if (!args[i]) {
       return false
     } else if (Array.isArray(args[i])) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,6 +924,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
       "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.9.0.tgz",
+      "integrity": "sha512-g795BBEzM/Hq2SYNPm/NQTIp3IWd4eXSH0ds87Na2jnrAUFX3wkyZAI4Gwj9DOaWMuz2/01i8oWI7P7T/XLkhg=="
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -4347,7 +4352,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4368,12 +4374,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4388,17 +4396,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4515,7 +4526,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4527,6 +4539,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4541,6 +4554,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4548,12 +4562,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4572,6 +4588,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4652,7 +4669,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4664,6 +4682,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4749,7 +4768,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4785,6 +4805,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4804,6 +4825,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4847,12 +4869,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "@date-io/date-fns": "^1.3.6",
+    "@fortawesome/fontawesome-free": "^5.9.0",
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.1",
     "@material-ui/lab": "^4.0.0-alpha.14",

--- a/server/api/stretch-answers.js
+++ b/server/api/stretch-answers.js
@@ -32,4 +32,12 @@ router.post('/create', (req, res, next) => {
     .catch(next)
 })
 
+router.put('/:id', (req, res, next) => {
+  StretchAnswer.findByPk(req.params.id)
+    .then(stretchAnswer => stretchAnswer.update(req.body))
+    .then(stretchAnswer => stretchAnswer.addAssociations())
+    .then(stretchAnswer => res.json(stretchAnswer))
+    .catch(next)
+})
+
 module.exports = router

--- a/server/db/methods/StretchAnswer.js
+++ b/server/db/methods/StretchAnswer.js
@@ -60,7 +60,7 @@ StretchAnswer.getAnswersOfStudentsOfSingleAdmin = function(adminId) {
         include: [
           {
             model: CohortStretch,
-            attributes: ['cohortId'],
+            attributes: ['cohortId', 'stretchId'],
             where: { cohortId: { [Op.in]: cohortIds } },
             include: [
               {
@@ -73,18 +73,6 @@ StretchAnswer.getAnswersOfStudentsOfSingleAdmin = function(adminId) {
       })
     })
     .then(stretchAnswers => {
-      return stretchAnswers.map(s => {
-        const values = s.get()
-        const { cohortstretch, ...itemValues } = values
-        const {
-          cohortId,
-          cohort: { name }
-        } = cohortstretch.get()
-        return {
-          ...itemValues,
-          cohortId,
-          cohortName: name
-        }
-      })
+      return stretchAnswers.map(sa => sa.format())
     })
 }


### PR DESCRIPTION
Implemented the following small things:

- when student submits stretch, app goes to their submitted stretches and that stretch doesn’t show in their list of of open stretches even if there’s time remaining
- admin home view now shows even if there are no stretch answers
- 5 stars appear to rank student’s answer when admin goes to student closed stretch view and answer hasn’t been rated yet
- code prompt appears in code editor on the stretch review component and in both of the code editors on the student closed stretch component. My reasoning here is that the code prompts usually have test calls of the function or variables to use when running an answer/solution so helpful to have the code prompt in those two places.
- admin can not reuse a stretch in cohort they previously used in cohort. So list of cohorts in shcedule picker is only cohorts they haven't given stretch in and if they have given it in all stretches, schedule button is disabled with tooltip explaining why. Maybe this is too strict but think at minimum should be warning they are reusing stretch. Code would be very similar

As definitely aleast those last two things we didn't discuss (and maybe the other things too), definitely fine with removing any of these features if you guys don't tihnk we should have them