### PR TITLE
Socket room to start timer

### DIFF
--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -8,11 +8,14 @@ import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 import { createStretchAnswerThunk } from '../../store/stretch-answers/actions'
 import { checkIfAllDataExists } from '../../utilityfunctions'
+import { joinCohortStretchRoomThunk } from '../../store/socket/actions'
 
 const mapDispatchToProps = dispatch => {
   return {
     createStretchAnswer: stretchAnswer =>
-      dispatch(createStretchAnswerThunk(stretchAnswer))
+      dispatch(createStretchAnswerThunk(stretchAnswer)),
+    joinCohortStretchRoom: cohortStretchId =>
+      dispatch(joinCohortStretchRoomThunk(cohortStretchId))
   }
 }
 
@@ -46,7 +49,8 @@ const OpenStretchView = ({
   myStretch,
   myCohortStretch,
   createStretchAnswer,
-  userDetails
+  userDetails,
+  joinCohortStretchRoom
 }) => {
   const classes = useStyles()
   const [codePrompt, setCodePrompt] = useState('')
@@ -60,6 +64,7 @@ const OpenStretchView = ({
       setStretchAnswer(myStretch.codePrompt)
     }
     if (myStretch && !remainingTime) {
+      joinCohortStretchRoom(myCohortStretch.id)
       setDisplayMinutes(myStretch.minutes - 1)
       setRemainingTime(myStretch.minutes * 60)
     }

--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -58,6 +58,7 @@ const OpenStretchView = ({
   const [displayMinutes, setDisplayMinutes] = useState(0)
   const [displaySeconds, setDisplaySeconds] = useState(59)
   const [stretchAnswer, setStretchAnswer] = useState('')
+
   useEffect(() => {
     if (myStretch) {
       setCodePrompt(myStretch.codePrompt)
@@ -69,23 +70,25 @@ const OpenStretchView = ({
       setRemainingTime(myStretch.minutes * 60)
     }
     if (myStretch && remainingTime) {
-      const timer = setTimeout(() => {
-        setRemainingTime(remainingTime - 1)
-        if (displaySeconds > 0) {
-          setDisplaySeconds(displaySeconds - 1)
-        } else {
-          setDisplaySeconds(59)
-          setDisplayMinutes(displayMinutes - 1)
+      if (myCohortStretch.startTimer) {
+        const timer = setTimeout(() => {
+          setRemainingTime(remainingTime - 1)
+          if (displaySeconds > 0) {
+            setDisplaySeconds(displaySeconds - 1)
+          } else {
+            setDisplaySeconds(59)
+            setDisplayMinutes(displayMinutes - 1)
+          }
+        }, 1000)
+        if (remainingTime === 1) {
+          clearTimeout(timer)
+          createStretchAnswer({
+            body: stretchAnswer,
+            timeToSolve: myStretch.minutes * 60 - remainingTime,
+            cohortstretchId: myCohortStretch.id,
+            userId: userDetails.id
+          })
         }
-      }, 1000)
-      if (remainingTime === 1) {
-        clearTimeout(timer)
-        createStretchAnswer({
-          body: stretchAnswer,
-          timeToSolve: myStretch.minutes * 60 - remainingTime,
-          cohortstretchId: myCohortStretch.id,
-          userId: userDetails.id
-        })
       }
     }
   })

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 
 import { connect } from 'react-redux'
 import { createStretch, updateStretch } from '../../store/stretches/actions'
+import { startStretchTimerThunk } from '../../store/cohort-stretches/actions'
 
 import Grid from '@material-ui/core/Grid'
 import TextField from '@material-ui/core/TextField'
@@ -42,6 +43,15 @@ class SingleStretch extends Component {
       attributes = stretches.find(s => s.id === match.params.id)
 
     this.setState({ mode, ...attributes, initialCode: attributes.codePrompt })
+  }
+
+  startTimer = () => {
+    const { cohortStretches, match } = this.props
+    let currCohortStretch = cohortStretches.find(
+      cs => cs.stretchId === match.params.id
+    )
+    currCohortStretch.startTimer = true
+    this.props.startStretchTimer(currCohortStretch)
   }
 
   handleChange = event => {
@@ -86,6 +96,7 @@ class SingleStretch extends Component {
 
   componentDidMount() {
     this.setStretchDetails()
+    this.startTimer()
   }
 
   componentDidUpdate(prevProps) {
@@ -165,12 +176,15 @@ SingleStretch.defaultProps = {
 
 const mapStateToProps = state => ({
   userDetails: state.userDetails,
-  stretches: state.stretches
+  stretches: state.stretches,
+  cohortStretches: state.cohortStretches
 })
 
 const mapDispatchToProps = dispatch => ({
   createStretch: newStretch => dispatch(createStretch(newStretch)),
-  updateStretch: updatedStretch => dispatch(updateStretch(updatedStretch))
+  updateStretch: updatedStretch => dispatch(updateStretch(updatedStretch)),
+  startStretchTimer: cohortStretch =>
+    dispatch(startStretchTimerThunk(cohortStretch))
 })
 
 export default connect(

--- a/client/store/cohort-stretches/actions.js
+++ b/client/store/cohort-stretches/actions.js
@@ -8,6 +8,7 @@ export const CREATE_COHORT_STRETCH = 'CREATE_COHORT_STRETCH'
 export const UPDATE_COHORT_STRETCH = 'UPDATE_COHORT_STRETCH'
 export const DELETE_COHORT_STRETCH = 'DELETE_COHORT_STRETCH'
 
+export const START_STRETCH_TIMER = 'START_STRETCH_TIMER'
 // --------------------------------------------------
 // Action creators
 
@@ -32,6 +33,10 @@ const deleteCohortStretch = cohortStretchId => ({
   cohortStretchId
 })
 
+export const startStretchTimer = cohortStretch => ({
+  type: START_STRETCH_TIMER,
+  cohortStretch
+})
 // --------------------------------------------------
 // CRUD thunks
 
@@ -64,4 +69,8 @@ export const deleteCohortStretchThunk = cohortStretchId => {
       .delete(`/api/cohort-stretches/${cohortStretchId}`)
       .then(() => dispatch(deleteCohortStretch(cohortStretchId)))
   }
+}
+
+export const startStretchTimerThunk = cohortStretch => dispatch => {
+  return dispatch(startStretchTimer(cohortStretch))
 }

--- a/client/store/cohort-stretches/reducer.js
+++ b/client/store/cohort-stretches/reducer.js
@@ -2,7 +2,8 @@ import {
   GET_COHORT_STRETCHES,
   CREATE_COHORT_STRETCH,
   UPDATE_COHORT_STRETCH,
-  DELETE_COHORT_STRETCH
+  DELETE_COHORT_STRETCH,
+  START_STRETCH_TIMER
 } from './actions'
 
 export default (state = [], action) => {
@@ -20,6 +21,11 @@ export default (state = [], action) => {
       ]
     case DELETE_COHORT_STRETCH:
       return state.filter(cs => cs.id !== action.cohortStretchId)
+    case START_STRETCH_TIMER:
+      return [
+        action.cohortStretch,
+        ...state.filter(cs => cs.id !== action.cohortStretch.id)
+      ]
     default:
       return state
   }

--- a/client/store/socket/Socket.js
+++ b/client/store/socket/Socket.js
@@ -35,6 +35,11 @@ class Socket {
       console.log('socket not connected')
     }
   }
+
+  joinCohortStretchRoom(cohortStretchId) {
+    this.socket.emit('joinCohortStretchRoom', cohortStretchId)
+    this.socket.on('success', msg => console.log(msg))
+  }
 }
 
 export default Socket

--- a/client/store/socket/Socket.js
+++ b/client/store/socket/Socket.js
@@ -1,6 +1,7 @@
 import io from 'socket.io-client'
 import { addComment } from '../comments/actions'
 import { setFlashMessage } from '../flash-message/actions'
+import { startStretchTimer } from '../cohort-stretches/actions'
 
 class Socket {
   constructor(userId, storeAPI) {
@@ -22,6 +23,10 @@ class Socket {
         storeAPI.dispatch(setFlashMessage(message, link))
       }
     )
+
+    this.socket.on('timer-started', cohortStretchId => {
+      storeAPI.dispatch(startStretchTimer(cohortStretchId))
+    })
   }
 
   disconnectUser() {
@@ -39,6 +44,10 @@ class Socket {
   joinCohortStretchRoom(cohortStretchId) {
     this.socket.emit('joinCohortStretchRoom', cohortStretchId)
     this.socket.on('success', msg => console.log(msg))
+  }
+
+  startStretchTimer(cohortStretch) {
+    this.socket.emit('startStretchTimer', cohortStretch)
   }
 }
 

--- a/client/store/socket/actions.js
+++ b/client/store/socket/actions.js
@@ -1,0 +1,21 @@
+import axios from 'axios'
+
+// --------------------------------------------------
+// Action types
+
+export const JOIN_COHORT_STRETCH_ROOM = 'JOIN_COHORT_STRETCH_ROOM'
+
+// --------------------------------------------------
+// Action creators
+
+const joinCohortStretchRoom = cohortStretchId => ({
+  type: JOIN_COHORT_STRETCH_ROOM,
+  cohortStretchId
+})
+
+// --------------------------------------------------
+// thunks
+
+export const joinCohortStretchRoomThunk = cohortStretchId => dispatch => {
+  return dispatch(joinCohortStretchRoom(cohortStretchId))
+}

--- a/client/store/socket/middleware.js
+++ b/client/store/socket/middleware.js
@@ -2,6 +2,7 @@ import Socket from './Socket'
 import { GET_USER_DETAILS, LOGOUT } from '../auth/actions'
 import { CREATE_COMMENT } from '../comments/actions'
 import { JOIN_COHORT_STRETCH_ROOM } from './actions'
+import { START_STRETCH_TIMER } from '../cohort-stretches/actions'
 
 const socketMiddleware = storeAPI => {
   let socket
@@ -18,6 +19,9 @@ const socketMiddleware = storeAPI => {
         break
       case JOIN_COHORT_STRETCH_ROOM:
         socket.joinCohortStretchRoom(action.cohortStretchId)
+        break
+      case START_STRETCH_TIMER:
+        socket.startStretchTimer(action.cohortStretch)
         break
       default:
         break

--- a/client/store/socket/middleware.js
+++ b/client/store/socket/middleware.js
@@ -1,6 +1,7 @@
 import Socket from './Socket'
 import { GET_USER_DETAILS, LOGOUT } from '../auth/actions'
 import { CREATE_COMMENT } from '../comments/actions'
+import { JOIN_COHORT_STRETCH_ROOM } from './actions'
 
 const socketMiddleware = storeAPI => {
   let socket
@@ -14,6 +15,9 @@ const socketMiddleware = storeAPI => {
         break
       case LOGOUT:
         socket.disconnectUser()
+        break
+      case JOIN_COHORT_STRETCH_ROOM:
+        socket.joinCohortStretchRoom(action.cohortStretchId)
         break
       default:
         break

--- a/server/db/models/CohortStretch.js
+++ b/server/db/models/CohortStretch.js
@@ -24,6 +24,11 @@ const CohortStretch = db.define('cohortstretch', {
   solution: {
     type: db.Sequelize.TEXT
   },
+  startTimer: {
+    type: db.Sequelize.BOOLEAN,
+    defaultValue: false,
+    allowNull: false
+  },
   scheduledDate: {
     type: db.Sequelize.DATE,
     allowNull: false,

--- a/server/socket.js
+++ b/server/socket.js
@@ -31,6 +31,21 @@ const socketFunction = socketServer => {
         }
       }
     })
+
+    socket.on('joinCohortStretchRoom', cohortStretchId => {
+      socket.join(cohortStretchId)
+      if (cohortStretchId) {
+        return socketServer.emit(
+          'success',
+          `you have joined room for cohort stretch id ${cohortStretchId}`
+        )
+      } else {
+        return socketServer.emit(
+          'err',
+          `the room for cohort stretch Id ${cohortStretchId} does not exist`
+        )
+      }
+    })
   })
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -34,6 +34,7 @@ const socketFunction = socketServer => {
 
     socket.on('joinCohortStretchRoom', cohortStretchId => {
       socket.join(cohortStretchId)
+
       if (cohortStretchId) {
         return socketServer.emit(
           'success',
@@ -45,6 +46,11 @@ const socketFunction = socketServer => {
           `the room for cohort stretch Id ${cohortStretchId} does not exist`
         )
       }
+    })
+
+    socket.on('startStretchTimer', cohortStretch => {
+      socket.to(cohortStretch.id).emit('timer-started', cohortStretch)
+      console.log('received request to start stretch timer')
     })
   })
 }


### PR DESCRIPTION
Sorry this took so long guys! Took me a minute to re-learn this socket stuff and then figure out how to make this work. Essentially, here is what happens:

1) If a student clicks on an "open" stretch, two things happen when the component renders:
- The student enters a websocket "room" by cohortStretchId that other students and admin can also enter
- The component shows a loaded timer that does not tick

2) When an admin of the same cohort clicks on the same "open" stretch, they also enter the socket room. When their stretch component mounts, the "setTimer" field on the associated cohort stretch is set to "true" and a thunk is dispatched to "set" the timer with the changed cohort stretch.

3) That thunk is intercepted by Steven's socket middleware, and the associated instance of the socket class for the user calls the "setTimer" method which makes a request to the socket server with the associated cohort stretch for which the admin wishes to set the timer.

4) Inside of the socket server, there is a listener which accepts the request, takes the cohort stretch, and sends it back to client side - at that point, the cohort stretch is dispatched to the redux store, which triggers the timer on the student's component. 

I think I explained that correctly. The timer code on the front end is still sloppy, but I will try to refactor this weekend.
