### PR TITLE
Submit stretch without code prompt

### DIFF
--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -31,11 +31,13 @@ class AceEditor extends Component {
       function() {
         const { editor } = this.state
         const editorSession = editor.getSession()
+        const codePromptRowCount = editorSession.getLength()
         this.configEditor(
           editor,
           editorSession,
           handleCodeChange,
-          codeTargetName
+          codeTargetName,
+          codePromptRowCount
         )
       }
     )

--- a/client/Components/CodeEditor/configeditor.js
+++ b/client/Components/CodeEditor/configeditor.js
@@ -55,10 +55,14 @@ const configEditor = function(
     handleCodeChange({
       target: {
         name: codeTargetName,
-        value: excludeCodePromptInStretchAnswer(
-          codePromptRowCount,
-          editorSession
-        )
+        value: `${
+          codeTargetName === 'code'
+            ? excludeCodePromptInStretchAnswer(
+                codePromptRowCount,
+                editorSession
+              )
+            : editorSession.getValue()
+        }`
       }
     })
   })

--- a/client/Components/CodeEditor/configeditor.js
+++ b/client/Components/CodeEditor/configeditor.js
@@ -17,11 +17,27 @@ const addClosingCurlyBracket = (editor, editorSession) => {
   }
 }
 
+const excludeCodePromptInStretchAnswer = (
+  codePromptRowCount,
+  editorSession
+) => {
+  let documentRowCount = editorSession.getLength()
+  const arrayOfStretchLines = editorSession.getLines(
+    codePromptRowCount,
+    documentRowCount
+  )
+  return arrayOfStretchLines.reduce((acc, line) => {
+    acc += `${line} \n`
+    return acc
+  }, [])
+}
+
 const configEditor = function(
   editor,
   editorSession,
   handleCodeChange,
-  codeTargetName
+  codeTargetName,
+  codePromptRowCount
 ) {
   editorSession.setMode('ace/mode/javascript')
   editor.setShowPrintMargin(false)
@@ -37,7 +53,13 @@ const configEditor = function(
   editorSession.on('change', () => {
     addClosingCurlyBracket(editor, editorSession)
     handleCodeChange({
-      target: { name: codeTargetName, value: editorSession.getValue() }
+      target: {
+        name: codeTargetName,
+        value: excludeCodePromptInStretchAnswer(
+          codePromptRowCount,
+          editorSession
+        )
+      }
     })
   })
 }

--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -70,7 +70,7 @@ const OpenStretchView = ({
   let [modalOpen, setModalOpen] = useState(false)
   const [codePrompt, setCodePrompt] = useState('')
   const [stretchAnswer, setStretchAnswer] = useState('')
-
+  console.log('stretch answer', stretchAnswer)
   const handleModalClose = () => {
     setModalOpen(false)
   }

--- a/client/Components/OpenStretchView/OpenStretchView.js
+++ b/client/Components/OpenStretchView/OpenStretchView.js
@@ -70,13 +70,11 @@ const OpenStretchView = ({
   let [modalOpen, setModalOpen] = useState(false)
   const [codePrompt, setCodePrompt] = useState('')
   const [stretchAnswer, setStretchAnswer] = useState('')
-  console.log('stretch answer', stretchAnswer)
   const handleModalClose = () => {
     setModalOpen(false)
   }
 
   const submitStretch = (stretchAnswer, myStretch, userDetails, history) => {
-    console.log('myStretch', myStretch)
     return createStretchAnswer({
       body: stretchAnswer,
       timeToSolve: myStretch.minutes * 60 - totalSecondsLeft,

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -143,7 +143,7 @@ class SingleStretch extends Component {
                   placeholder="Enter your written prompt here."
                   helperText="This is to be substituted with a rich text editor."
                   fullWidth
-                  multiline="true"
+                  multiline={true}
                   margin="normal"
                   InputLabelProps={{
                     shrink: true


### PR DESCRIPTION
Added a function to the editor config file that essentially identifies the lines occupied by the code prompt, and excludes them from the stretch answer when the change is handled.