### PR TITLE
Refactoring single cohort stretches + solving bugs

### DIFF
--- a/bin/seed.js
+++ b/bin/seed.js
@@ -103,7 +103,7 @@ const createStretchObjects = (userIds, categoryIds) => {
       codePrompt: `${paragraph()}\n \n/*your code below --------------------------------------------------------------*/`,
       difficulty:
         Math.random() <= 0.7 ? getRandomArrayEntry([1, 2, 3, 4, 5]) : null,
-      minutes: getRandomArrayEntry([2]),
+      minutes: getRandomArrayEntry([1]),
       language: 'jsx',
       authorId: getRandomArrayEntry(userIds),
       categoryId: getRandomArrayEntry(categoryIds)

--- a/client/Components/SingleCohort/ClosedStretchLinks.js
+++ b/client/Components/SingleCohort/ClosedStretchLinks.js
@@ -1,0 +1,23 @@
+import React, { Fragment } from 'react'
+import TableCell from '@material-ui/core/TableCell'
+import Button from '@material-ui/core/Button'
+import { Link } from 'react-router-dom'
+
+const ClosedStretchLinks = ({ cohortStretchId, stretchId }) => {
+  return (
+    <Fragment>
+      <TableCell>
+        <Link to={`/admin/stretch/analytics/${stretchId}`}>
+          <Button color="primary"> View Analytics </Button>
+        </Link>
+      </TableCell>
+      <TableCell>
+        <Link to={`/admin/stretchReview/${cohortStretchId}`}>
+          <Button>Go To Classroom</Button>
+        </Link>
+      </TableCell>
+    </Fragment>
+  )
+}
+
+export default ClosedStretchLinks

--- a/client/Components/SingleCohort/ScheduledStretchButtons.js
+++ b/client/Components/SingleCohort/ScheduledStretchButtons.js
@@ -1,0 +1,41 @@
+import React, { Fragment } from 'react'
+import TableCell from '@material-ui/core/TableCell'
+import Button from '@material-ui/core/Button'
+
+const ScheduledStretchButtons = ({
+  handleopenStretchModalOpen,
+  handleRescheduleModalOpen,
+  handleunscheduleModalOpen,
+  cohortStretch
+}) => {
+  return (
+    <Fragment>
+      <TableCell>
+        <Button onClick={() => handleopenStretchModalOpen(cohortStretch)}>
+          {' '}
+          Open{' '}
+        </Button>
+      </TableCell>
+      <TableCell>
+        <Button
+          color="primary"
+          onClick={() => handleRescheduleModalOpen(cohortStretch)}
+        >
+          {' '}
+          Reschedule{' '}
+        </Button>
+      </TableCell>
+      <TableCell>
+        <Button
+          color="secondary"
+          onClick={() => handleunscheduleModalOpen(cohortStretch.id)}
+        >
+          {' '}
+          Unschedule{' '}
+        </Button>
+      </TableCell>
+    </Fragment>
+  )
+}
+
+export default ScheduledStretchButtons

--- a/client/Components/SingleCohort/ScheduledStretchButtons.js
+++ b/client/Components/SingleCohort/ScheduledStretchButtons.js
@@ -28,7 +28,7 @@ const ScheduledStretchButtons = ({
       <TableCell>
         <Button
           color="secondary"
-          onClick={() => handleunscheduleModalOpen(cohortStretch.id)}
+          onClick={() => handleunscheduleModalOpen(cohortStretch)}
         >
           {' '}
           Unschedule{' '}

--- a/client/Components/SingleCohort/SingleCohortStretchTables.js
+++ b/client/Components/SingleCohort/SingleCohortStretchTables.js
@@ -1,43 +1,15 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
-import { Link } from 'react-router-dom'
-import moment from 'moment'
-import {
-  deleteCohortStretchThunk,
-  updateCohortStretchThunk
-} from '../../store/cohort-stretches/actions'
-import { openStretchProcessThunk } from '../../store/shared-actions'
 import { checkIfAllDataExists } from '../../utilityfunctions'
 
-import StretchScheduler from '../_shared/StretchScheduler'
-import ConfirmDialogBox from '../_shared/ConfirmDialogBox'
-import Table from '@material-ui/core/Table'
-import TableHead from '@material-ui/core/TableHead'
-import TableBody from '@material-ui/core/TableBody'
-import TableRow from '@material-ui/core/TableRow'
-import TableCell from '@material-ui/core/TableCell'
-import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
 import SingleTable from './SingleTable'
 import { formatCohortStretch } from '../StudentHomeView/helperfunctions'
 
-const SingleCohortStretchTables = ({
-  cohort,
-  cohortStretches,
-  stretches,
-  deleteCohortStretch,
-  updateCohortStretch,
-  openStretchProcess
-}) => {
+const SingleCohortStretchTables = ({ cohort, cohortStretches, stretches }) => {
   if (!checkIfAllDataExists(cohort, cohortStretches, stretches)) {
     return <div>No open, scheduled, or submitted stretches for cohort</div>
   }
-
-  let [rescheduleModalOpen, setRescheduleModalOpen] = useState(false)
-  let [unscheduleModalOpen, setunscheduleModalOpen] = useState(false)
-  let [openStretchModalOpen, setOpenStretchModalOpen] = useState(false)
-  let [selectedCohortStretch, setCohortStretch] = useState({})
-  let [selectedCohortStretchId, setCohortStretchId] = useState('')
 
   const thisCohortStretches =
     cohortStretches.filter(
@@ -61,42 +33,15 @@ const SingleCohortStretchTables = ({
     closed: closedCohortStretches
   }
 
-  // StretchScheduler modal event handlers
-  const handleRescheduleModalClose = () => setRescheduleModalOpen(false)
-  const handleRescheduleModalOpen = selectedCohortStretch => {
-    setRescheduleModalOpen(true)
-    setCohortStretch(selectedCohortStretch)
-  }
-
-  // Unschedule modal event handlers
-  const handleunscheduleModalClose = () => setunscheduleModalOpen(false)
-  const handleunscheduleModalOpen = id => {
-    setunscheduleModalOpen(true)
-    setCohortStretchId(id)
-  }
-
-  // open stretch modal event handlers
-  const handleopenStretchModalClose = () => setOpenStretchModalOpen(false)
-  const handleopenStretchModalOpen = cohortStretch => {
-    setOpenStretchModalOpen(true)
-    setCohortStretch(cohortStretch)
-    setCohortStretchId(cohortStretch.id)
-  }
-
-  const baseColumnNames = ['Title', 'Author', 'Category', 'Difficulty']
+  const baseColumnNames = ['Title', 'Author', 'Category']
   const tableColumnNames = {
-    open: baseColumnNames,
-    scheduled: [...baseColumnNames, 'Scheduled Date'],
-    closed: [...baseColumnNames, 'Date Used On ']
+    open: [...baseColumnNames, 'Difficulty'],
+    scheduled: [...baseColumnNames, 'Scheduled Date', '', '', ''],
+    closed: [...baseColumnNames, 'Date Opened On', '', '']
   }
-  const baseDBColumnNames = [
-    'title',
-    'authorName',
-    'categoryName',
-    'difficulty'
-  ]
+  const baseDBColumnNames = ['title', 'authorName', 'categoryName']
   const dbColumnNames = {
-    open: baseDBColumnNames,
+    open: [...baseDBColumnNames, 'difficulty'],
     scheduled: [...baseDBColumnNames, 'scheduledDate'],
     closed: [...baseDBColumnNames, 'startTimer']
   }
@@ -108,32 +53,6 @@ const SingleCohortStretchTables = ({
 
   return (
     <div>
-      <StretchScheduler
-        open={rescheduleModalOpen}
-        onClose={handleRescheduleModalClose}
-        attributes={selectedCohortStretch}
-        mode="update"
-      />
-      <ConfirmDialogBox
-        text="Are you sure you would like to unschedule the stretch?"
-        open={unscheduleModalOpen}
-        setModalClosed={handleunscheduleModalClose}
-        args={[selectedCohortStretchId]}
-        action={deleteCohortStretch}
-        showNoButton={true}
-      />
-      <ConfirmDialogBox
-        text="Are you sure you would like to open the stretch?"
-        open={openStretchModalOpen}
-        setModalClosed={handleopenStretchModalClose}
-        args={[
-          stretches.find(s => s.id === selectedCohortStretch.stretchId),
-          selectedCohortStretchId,
-          { status: 'open', startTimer: new Date() }
-        ]}
-        action={openStretchProcess}
-        showNoButton={true}
-      />
       {tables.map(table => {
         const { key, title } = table
         return (
@@ -145,147 +64,11 @@ const SingleCohortStretchTables = ({
               data={groupedStretches[key]}
               dbColumnNames={dbColumnNames[key]}
               tableColumnNames={tableColumnNames[key]}
+              status={key}
             />
           </div>
         )
       })}
-
-      {/*   <Typography variant="h6" id="tableTitle">
-        Open Stretches
-      </Typography>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Title</TableCell>
-            <TableCell>Author</TableCell>
-            <TableCell>Category</TableCell>
-            <TableCell>Difficulty</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {openCohortStretches.map(cohortStretch => {
-            const { id, stretch } = cohortStretch
-            return (
-              <TableRow key={id}>
-                <TableCell>
-                  <Link to={`/admin/singleStretch/${stretch.id}`}>
-                    {stretch.title}
-                  </Link>
-                </TableCell>
-                <TableCell>{stretch.authorName}</TableCell>
-                <TableCell>{stretch.categoryName}</TableCell>
-                <TableCell>{stretch.difficulty}</TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-
-      <Typography variant="h6" id="tableTitle">
-        Scheduled Stretches
-      </Typography>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Title</TableCell>
-            <TableCell>Author</TableCell>
-            <TableCell>Category</TableCell>
-            <TableCell>Difficulty</TableCell>
-            <TableCell>Scheduled Date</TableCell>
-            <TableCell />
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {scheduledCohortStretches.map(cohortStretch => {
-            const { stretch } = cohortStretch
-            return (
-              <TableRow key={cohortStretch.id}>
-                <TableCell>
-                  <Link to={`/admin/singleStretch/${stretch.id}`}>
-                    {stretch.title}
-                  </Link>
-                </TableCell>
-                <TableCell>{stretch.authorName}</TableCell>
-                <TableCell>{stretch.categoryName}</TableCell>
-                <TableCell>{stretch.difficulty}</TableCell>
-                <TableCell>
-                  {moment
-                    .utc(cohortStretch.scheduledDate)
-                    .local()
-                    .format('MMMM D, h:mm A')}
-                </TableCell>
-                <TableCell>
-                  <Button
-                    onClick={() => handleopenStretchModalOpen(cohortStretch)}
-                  >
-                    {' '}
-                    Open{' '}
-                  </Button>
-                  <Button
-                    color="primary"
-                    onClick={() => handleRescheduleModalOpen(cohortStretch)}
-                  >
-                    {' '}
-                    Reschedule{' '}
-                  </Button>
-                </TableCell>
-                <TableCell>
-                  <Button
-                    color="secondary"
-                    onClick={() => handleunscheduleModalOpen(cohortStretch.id)}
-                  >
-                    {' '}
-                    Unschedule{' '}
-                  </Button>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-
-      <Typography variant="h6" id="tableTitle">
-        Closed Stretches
-      </Typography>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Title</TableCell>
-            <TableCell>Author</TableCell>
-            <TableCell>Category</TableCell>
-            <TableCell>Difficulty</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {closedCohortStretches.map(cs => {
-            const { id, stretch } = cs
-            return (
-              <TableRow key={id}>
-                <TableCell>
-                  <Link to={`/admin/singleStretch/${stretch.id}`}>
-                    {stretch.title}
-                  </Link>
-                </TableCell>
-                <TableCell>{stretch.authorName}</TableCell>
-                <TableCell>{stretch.categoryName}</TableCell>
-                <TableCell>{stretch.difficulty}</TableCell>
-                <TableCell>
-                  <Link to={`/admin/stretch/analytics/${stretch.id}`}>
-                    <Button color="primary"> View Analytics </Button>
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <Link to={`/admin/stretchReview/${id}`}>
-                    <Button>Go To Classroom</Button>
-                  </Link>
-                </TableCell>
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>*/}
     </div>
   )
 }
@@ -295,17 +78,4 @@ const mapStateToProps = ({ cohortStretches, stretches }) => ({
   stretches
 })
 
-const mapDispatchToProps = dispatch => {
-  return {
-    deleteCohortStretch: id => dispatch(deleteCohortStretchThunk(id)),
-    updateCohortStretch: (id, updatedFields) =>
-      dispatch(updateCohortStretchThunk(id, updatedFields)),
-    openStretchProcess: (stretch, cohortStretchId, updatedFields) =>
-      dispatch(openStretchProcessThunk(stretch, cohortStretchId, updatedFields))
-  }
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SingleCohortStretchTables)
+export default connect(mapStateToProps)(SingleCohortStretchTables)

--- a/client/Components/SingleCohort/SingleCohortStretchTables.js
+++ b/client/Components/SingleCohort/SingleCohortStretchTables.js
@@ -18,6 +18,8 @@ import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
 import Button from '@material-ui/core/Button'
 import Typography from '@material-ui/core/Typography'
+import SingleTable from './SingleTable'
+import { formatCohortStretch } from '../StudentHomeView/helperfunctions'
 
 const SingleCohortStretchTables = ({
   cohort,
@@ -44,24 +46,20 @@ const SingleCohortStretchTables = ({
   const openCohortStretches =
     thisCohortStretches
       .filter(cohortStretches => cohortStretches.status === 'open')
-      .map(cs => ({
-        ...cs,
-        stretch: stretches.find(s => s.id === cs.stretchId)
-      })) || []
+      .map(cs => formatCohortStretch(cs, stretches)) || []
   const closedCohortStretches =
     thisCohortStretches
       .filter(cohortStretches => cohortStretches.status === 'closed')
-      .map(cs => ({
-        ...cs,
-        stretch: stretches.find(s => s.id === cs.stretchId)
-      })) || []
+      .map(cs => formatCohortStretch(cs, stretches)) || []
   const scheduledCohortStretches =
     thisCohortStretches
       .filter(cohortStretches => cohortStretches.status === 'scheduled')
-      .map(cs => ({
-        ...cs,
-        stretch: stretches.find(s => s.id === cs.stretchId)
-      })) || []
+      .map(cs => formatCohortStretch(cs, stretches)) || []
+  const groupedStretches = {
+    open: openCohortStretches,
+    scheduled: scheduledCohortStretches,
+    closed: closedCohortStretches
+  }
 
   // StretchScheduler modal event handlers
   const handleRescheduleModalClose = () => setRescheduleModalOpen(false)
@@ -84,6 +82,29 @@ const SingleCohortStretchTables = ({
     setCohortStretch(cohortStretch)
     setCohortStretchId(cohortStretch.id)
   }
+
+  const baseColumnNames = ['Title', 'Author', 'Category', 'Difficulty']
+  const tableColumnNames = {
+    open: baseColumnNames,
+    scheduled: [...baseColumnNames, 'Scheduled Date'],
+    closed: [...baseColumnNames, 'Date Used On ']
+  }
+  const baseDBColumnNames = [
+    'title',
+    'authorName',
+    'categoryName',
+    'difficulty'
+  ]
+  const dbColumnNames = {
+    open: baseDBColumnNames,
+    scheduled: [...baseDBColumnNames, 'scheduledDate'],
+    closed: [...baseDBColumnNames, 'startTimer']
+  }
+  const tables = [
+    { title: 'Open Stretches', key: 'open' },
+    { title: 'Scheduled Stretches', key: 'scheduled' },
+    { title: 'Closed Stretches', key: 'closed' }
+  ]
 
   return (
     <div>
@@ -113,7 +134,23 @@ const SingleCohortStretchTables = ({
         action={openStretchProcess}
         showNoButton={true}
       />
-      <Typography variant="h6" id="tableTitle">
+      {tables.map(table => {
+        const { key, title } = table
+        return (
+          <div key={key}>
+            <Typography variant="h6" id="tableTitle">
+              {title}
+            </Typography>
+            <SingleTable
+              data={groupedStretches[key]}
+              dbColumnNames={dbColumnNames[key]}
+              tableColumnNames={tableColumnNames[key]}
+            />
+          </div>
+        )
+      })}
+
+      {/*   <Typography variant="h6" id="tableTitle">
         Open Stretches
       </Typography>
       <Table>
@@ -248,7 +285,7 @@ const SingleCohortStretchTables = ({
             )
           })}
         </TableBody>
-      </Table>
+      </Table>*/}
     </div>
   )
 }

--- a/client/Components/SingleCohort/SingleCohortStretchTables.js
+++ b/client/Components/SingleCohort/SingleCohortStretchTables.js
@@ -1,8 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { checkIfAllDataExists } from '../../utilityfunctions'
 
+import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
+import ListItem from '@material-ui/core/ListItem'
+import ExpandLess from '@material-ui/icons/ExpandLess'
+import ExpandMore from '@material-ui/icons/ExpandMore'
+import Collapse from '@material-ui/core/Collapse'
 import SingleTable from './SingleTable'
 import { formatCohortStretch } from '../StudentHomeView/helperfunctions'
 
@@ -54,18 +59,36 @@ const SingleCohortStretchTables = ({ cohort, cohortStretches, stretches }) => {
   return (
     <div>
       {tables.map(table => {
+        let [expandedTable, setExpandTable] = useState(true)
         const { key, title } = table
         return (
           <div key={key}>
-            <Typography variant="h6" id="tableTitle">
-              {title}
-            </Typography>
-            <SingleTable
-              data={groupedStretches[key]}
-              dbColumnNames={dbColumnNames[key]}
-              tableColumnNames={tableColumnNames[key]}
-              status={key}
-            />
+            <ListItem
+              button
+              onClick={() => {
+                console.log(expandedTable)
+                setExpandTable(!expandedTable)
+              }}
+            >
+              <Grid container>
+                <Grid item xs={6}>
+                  <Typography variant="h6" id="tableTitle">
+                    {title}
+                  </Typography>
+                </Grid>
+                <Grid item xs={6} style={{ textAlign: 'right' }}>
+                  {expandedTable ? <ExpandLess /> : <ExpandMore />}
+                </Grid>
+              </Grid>
+            </ListItem>
+            <Collapse in={expandedTable} timeout="auto" unmountOnExit>
+              <SingleTable
+                data={groupedStretches[key]}
+                dbColumnNames={dbColumnNames[key]}
+                tableColumnNames={tableColumnNames[key]}
+                status={key}
+              />
+            </Collapse>
           </div>
         )
       })}

--- a/client/Components/SingleCohort/SingleTable.js
+++ b/client/Components/SingleCohort/SingleTable.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import Table from '@material-ui/core/Table'
 import TableHead from '@material-ui/core/TableHead'
@@ -6,63 +6,163 @@ import TableBody from '@material-ui/core/TableBody'
 import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
 import moment from 'moment'
+import { deleteCohortStretchThunk } from '../../store/cohort-stretches/actions'
+import { openStretchProcessThunk } from '../../store/shared-actions'
+import { connect } from 'react-redux'
 
-const SingleTable = ({ data, dbColumnNames, tableColumnNames }) => {
+import StretchScheduler from '../_shared/StretchScheduler'
+import ConfirmDialogBox from '../_shared/ConfirmDialogBox'
+import ScheduledStretchButtons from './ScheduledStretchButtons'
+import ClosedStretchLinks from './ClosedStretchLinks'
+
+const SingleTable = ({
+  data,
+  dbColumnNames,
+  tableColumnNames,
+  status,
+  openStretchProcess,
+  deleteCohortStretch,
+  stretches
+}) => {
+  let [rescheduleModalOpen, setRescheduleModalOpen] = useState(false)
+  let [unscheduleModalOpen, setunscheduleModalOpen] = useState(false)
+  let [openStretchModalOpen, setOpenStretchModalOpen] = useState(false)
+  let [selectedCohortStretch, setCohortStretch] = useState({})
+
+  // StretchScheduler modal event handlers
+  const handleRescheduleModalClose = () => setRescheduleModalOpen(false)
+  const handleRescheduleModalOpen = selectedCohortStretch => {
+    setRescheduleModalOpen(true)
+    setCohortStretch({
+      ...selectedCohortStretch,
+      id: selectedCohortStretch.cohortStretchId
+    })
+  }
+
+  // Unschedule modal event handlers
+  const handleunscheduleModalClose = () => setunscheduleModalOpen(false)
+  const handleunscheduleModalOpen = cohortStretch => {
+    setunscheduleModalOpen(true)
+    setCohortStretch(cohortStretch)
+  }
+
+  // open stretch modal event handlers
+  const handleopenStretchModalClose = () => setOpenStretchModalOpen(false)
+  const handleopenStretchModalOpen = cohortStretch => {
+    setOpenStretchModalOpen(true)
+    setCohortStretch(cohortStretch)
+  }
+
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          {tableColumnNames.map((column, index) => {
-            if (column !== '') {
-              return (
-                <TableCell key={index}>
-                  {/*} <TableSortLabel
+    <div>
+      <StretchScheduler
+        open={rescheduleModalOpen}
+        onClose={handleRescheduleModalClose}
+        attributes={selectedCohortStretch}
+        mode="update"
+      />
+      <ConfirmDialogBox
+        text="Are you sure you would like to unschedule the stretch?"
+        open={unscheduleModalOpen}
+        setModalClosed={handleunscheduleModalClose}
+        args={[selectedCohortStretch.cohortStretchId]}
+        action={deleteCohortStretch}
+        showNoButton={true}
+      />
+      <ConfirmDialogBox
+        text="Are you sure you would like to open the stretch?"
+        open={openStretchModalOpen}
+        setModalClosed={handleopenStretchModalClose}
+        args={[
+          stretches.find(s => s.id === selectedCohortStretch.stretchId),
+          selectedCohortStretch.cohortStretchId,
+          { status: 'open', startTimer: new Date() }
+        ]}
+        action={openStretchProcess}
+        showNoButton={true}
+      />
+      <Table>
+        <TableHead>
+          <TableRow>
+            {tableColumnNames.map((column, index) => {
+              if (column !== '') {
+                return (
+                  <TableCell key={index}>
+                    {/*} <TableSortLabel
                   direction={orderDirection}
                   active={orderColumn === column}
                   onClick={() => onRequestSort(dbColumnNames[status][index])}
             >*/}{' '}
-                  {column}
-                  {/* </TableSortLabel>*/}
-                </TableCell>
-              )
-            }
-            return <TableCell key={index} />
-          })}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {data.map((item, idx) => {
-          return (
-            <TableRow key={idx}>
-              {dbColumnNames.map((field, idx) => {
-                if (idx === 0) {
-                  return (
-                    <TableCell key={idx} component="th" scope="row">
-                      <Link to={`/admin/singleStretch/${item.stretchId}`}>
-                        {item[field]}
-                      </Link>
-                    </TableCell>
-                  )
-                }
-                return (
-                  <TableCell key={idx} align="right">
-                    {['startTimer', 'scheduledDate'].includes(field) &&
-                      moment
-                        .utc(item[field])
-                        .local()
-                        .format('LL')}
-
-                    {!['startTimer', 'scheduledDate'].includes(field) &&
-                      item[field]}
+                    {column}
+                    {/* </TableSortLabel>*/}
                   </TableCell>
                 )
-              })}
-            </TableRow>
-          )
-        })}
-      </TableBody>
-    </Table>
+              }
+              return <TableCell key={index} />
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((item, idx) => {
+            return (
+              <TableRow key={idx}>
+                {dbColumnNames.map((field, idx) => {
+                  if (idx === 0) {
+                    return (
+                      <TableCell key={idx}>
+                        <Link to={`/admin/singleStretch/${item.stretchId}`}>
+                          {item[field]}
+                        </Link>
+                      </TableCell>
+                    )
+                  }
+                  return (
+                    <TableCell key={idx}>
+                      {['startTimer', 'scheduledDate'].includes(field) &&
+                        moment
+                          .utc(item[field])
+                          .local()
+                          .format('LLL')}
+
+                      {!['startTimer', 'scheduledDate'].includes(field) &&
+                        item[field]}
+                    </TableCell>
+                  )
+                })}
+                {status === 'scheduled' && (
+                  <ScheduledStretchButtons
+                    cohortStretch={item}
+                    {...{
+                      handleRescheduleModalOpen,
+                      handleopenStretchModalOpen,
+                      handleunscheduleModalOpen
+                    }}
+                  />
+                )}
+                {status === 'closed' && (
+                  <ClosedStretchLinks
+                    cohortStretchId={item.cohortStretchId}
+                    stretchId={item.stretchId}
+                  />
+                )}
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
   )
 }
 
-export default SingleTable
+const mapDispatchToProps = dispatch => {
+  return {
+    deleteCohortStretch: id => dispatch(deleteCohortStretchThunk(id)),
+    openStretchProcess: (stretch, cohortStretchId, updatedFields) =>
+      dispatch(openStretchProcessThunk(stretch, cohortStretchId, updatedFields))
+  }
+}
+
+export default connect(
+  ({ stretches }) => ({ stretches }),
+  mapDispatchToProps
+)(SingleTable)

--- a/client/Components/SingleCohort/SingleTable.js
+++ b/client/Components/SingleCohort/SingleTable.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import Table from '@material-ui/core/Table'
+import TableHead from '@material-ui/core/TableHead'
+import TableBody from '@material-ui/core/TableBody'
+import TableRow from '@material-ui/core/TableRow'
+import TableCell from '@material-ui/core/TableCell'
+import moment from 'moment'
+
+const SingleTable = ({ data, dbColumnNames, tableColumnNames }) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {tableColumnNames.map((column, index) => {
+            if (column !== '') {
+              return (
+                <TableCell key={index}>
+                  {/*} <TableSortLabel
+                  direction={orderDirection}
+                  active={orderColumn === column}
+                  onClick={() => onRequestSort(dbColumnNames[status][index])}
+            >*/}{' '}
+                  {column}
+                  {/* </TableSortLabel>*/}
+                </TableCell>
+              )
+            }
+            return <TableCell key={index} />
+          })}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {data.map((item, idx) => {
+          return (
+            <TableRow key={idx}>
+              {dbColumnNames.map((field, idx) => {
+                if (idx === 0) {
+                  return (
+                    <TableCell key={idx} component="th" scope="row">
+                      <Link to={`/admin/singleStretch/${item.stretchId}`}>
+                        {item[field]}
+                      </Link>
+                    </TableCell>
+                  )
+                }
+                return (
+                  <TableCell key={idx} align="right">
+                    {['startTimer', 'scheduledDate'].includes(field) &&
+                      moment
+                        .utc(item[field])
+                        .local()
+                        .format('LL')}
+
+                    {!['startTimer', 'scheduledDate'].includes(field) &&
+                      item[field]}
+                  </TableCell>
+                )
+              })}
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+export default SingleTable

--- a/client/Components/SingleCohort/SingleTable.js
+++ b/client/Components/SingleCohort/SingleTable.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import Table from '@material-ui/core/Table'
-import TableHead from '@material-ui/core/TableHead'
 import TableBody from '@material-ui/core/TableBody'
 import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
@@ -14,6 +13,8 @@ import StretchScheduler from '../_shared/StretchScheduler'
 import ConfirmDialogBox from '../_shared/ConfirmDialogBox'
 import ScheduledStretchButtons from './ScheduledStretchButtons'
 import ClosedStretchLinks from './ClosedStretchLinks'
+import SortedTableHead from '../_shared/SortedTableHead'
+import { sortData } from '../../utilityfunctions'
 
 const SingleTable = ({
   data,
@@ -28,6 +29,8 @@ const SingleTable = ({
   let [unscheduleModalOpen, setunscheduleModalOpen] = useState(false)
   let [openStretchModalOpen, setOpenStretchModalOpen] = useState(false)
   let [selectedCohortStretch, setCohortStretch] = useState({})
+  let [orderDirection, setOrderDirection] = useState('desc')
+  let [orderColumn, setOrderColumn] = useState('')
 
   // StretchScheduler modal event handlers
   const handleRescheduleModalClose = () => setRescheduleModalOpen(false)
@@ -53,6 +56,8 @@ const SingleTable = ({
     setCohortStretch(cohortStretch)
   }
 
+  let dataDisplay =
+    orderColumn === '' ? data : sortData(data, orderColumn, orderDirection)
   return (
     <div>
       <StretchScheduler
@@ -82,28 +87,20 @@ const SingleTable = ({
         showNoButton={true}
       />
       <Table>
-        <TableHead>
-          <TableRow>
-            {tableColumnNames.map((column, index) => {
-              if (column !== '') {
-                return (
-                  <TableCell key={index}>
-                    {/*} <TableSortLabel
-                  direction={orderDirection}
-                  active={orderColumn === column}
-                  onClick={() => onRequestSort(dbColumnNames[status][index])}
-            >*/}{' '}
-                    {column}
-                    {/* </TableSortLabel>*/}
-                  </TableCell>
-                )
-              }
-              return <TableCell key={index} />
-            })}
-          </TableRow>
-        </TableHead>
+        <SortedTableHead
+          columns={tableColumnNames.map((name, index) => ({
+            displayName: name,
+            dataName: dbColumnNames[index]
+          }))}
+          {...{
+            setOrderDirection,
+            orderDirection,
+            setOrderColumn,
+            orderColumn
+          }}
+        />
         <TableBody>
-          {data.map((item, idx) => {
+          {dataDisplay.map((item, idx) => {
             return (
               <TableRow key={idx}>
                 {dbColumnNames.map((field, idx) => {

--- a/client/Components/StudentHomeView/StretchListView.js
+++ b/client/Components/StudentHomeView/StretchListView.js
@@ -4,11 +4,11 @@ import { makeStyles } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
-import TableHead from '@material-ui/core/TableHead'
-import TableSortLabel from '@material-ui/core/TableSortLabel'
 import TableRow from '@material-ui/core/TableRow'
 import Paper from '@material-ui/core/Paper'
 import moment from 'moment'
+import { sortData } from '../../utilityfunctions'
+import SortedTableHead from '../_shared/SortedTableHead'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -25,20 +25,9 @@ function StretchListView({ stretches, status }) {
   const classes = useStyles()
   let [orderDirection, setOrderDirection] = useState('desc')
   let [orderColumn, setOrderColumn] = useState('')
-  const onRequestSort = column => {
-    setOrderColumn(column)
-    setOrderDirection(orderDirection === 'desc' ? 'asc' : 'desc')
-  }
-
   let stretchesSorted = stretches
   if (orderColumn) {
-    stretchesSorted = stretchesSorted.sort((a, b) => {
-      if (a[orderColumn] < b[orderColumn])
-        return orderDirection === 'desc' ? 1 : -1
-      if (a[orderColumn] > b[orderColumn])
-        return orderDirection === 'desc' ? -1 : 1
-      return 0
-    })
+    stretchesSorted = sortData(stretchesSorted, orderColumn, orderDirection)
   }
 
   const tableColumnNames = {
@@ -72,27 +61,19 @@ function StretchListView({ stretches, status }) {
   return (
     <Paper className={classes.root}>
       <Table className={classes.table}>
-        <TableHead>
-          <TableRow>
-            {tableColumnNames[status].map((column, index) => {
-              return (
-                <TableCell
-                  key={index}
-                  align={index === 0 ? 'inherit' : 'right'}
-                >
-                  <TableSortLabel
-                    direction={orderDirection}
-                    active={orderColumn === column}
-                    onClick={() => onRequestSort(dbColumnNames[status][index])}
-                  >
-                    {' '}
-                    {column}
-                  </TableSortLabel>
-                </TableCell>
-              )
-            })}
-          </TableRow>
-        </TableHead>
+        <SortedTableHead
+          columns={tableColumnNames[status].map((name, index) => ({
+            displayName: name,
+            dataName: dbColumnNames[status][index]
+          }))}
+          align="right"
+          {...{
+            setOrderDirection,
+            orderDirection,
+            setOrderColumn,
+            orderColumn
+          }}
+        />
         <TableBody>
           {stretchesSorted.map((s, idx) => {
             return (

--- a/client/Components/StudentHomeView/helperfunctions.js
+++ b/client/Components/StudentHomeView/helperfunctions.js
@@ -1,11 +1,9 @@
-import moment from 'moment'
-
 const getStretchAndFormat = (stretches, stretchId) => {
   const { id, ...otherStretchFields } = stretches.find(s => s.id === stretchId)
   return { stretchId: id, ...otherStretchFields }
 }
 
-const formatCohortStretch = (cohortStretch, stretches) => {
+export const formatCohortStretch = (cohortStretch, stretches) => {
   const { id, stretchId, ...otherFields } = cohortStretch
   return {
     cohortStretchId: id,

--- a/client/Components/_shared/SingleStretchCard.js
+++ b/client/Components/_shared/SingleStretchCard.js
@@ -93,17 +93,15 @@ const SingleStretchCard = ({
           {status === 'open' && (
             <Grid item xs={12} md={6}>
               <Timer
+                answeringWhenStretchOpen={true}
                 minutesForStretch={minutes}
                 timeStretchStarted={startTimer}
-                action={
-                  userDetails.isAdmin
-                    ? closeStretchProcess
-                    : updateCohortStretch
-                }
+                action={!userDetails.isAdmin && updateCohortStretch}
                 args={
-                  userDetails.isAdmin
-                    ? [cohortStretchId]
-                    : [cohortStretch.id, { ...cohortStretch, status: 'closed' }]
+                  !userDetails.isAdmin && [
+                    cohortStretch.id,
+                    { ...cohortStretch, status: 'closed' }
+                  ]
                 }
                 {...{ totalSecondsLeft, setTotalSecondsLeft }}
               />

--- a/client/Components/_shared/SortedTableHead.js
+++ b/client/Components/_shared/SortedTableHead.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import TableHead from '@material-ui/core/TableHead'
+import TableRow from '@material-ui/core/TableRow'
+import TableCell from '@material-ui/core/TableCell'
+import TableSortLabel from '@material-ui/core/TableSortLabel'
+
+const SortedTableHead = ({
+  columns,
+  align,
+  setOrderDirection,
+  orderDirection,
+  setOrderColumn,
+  orderColumn
+}) => {
+  const onRequestSort = column => {
+    setOrderColumn(column)
+    setOrderDirection(orderDirection === 'desc' ? 'asc' : 'desc')
+  }
+  return (
+    <TableHead>
+      <TableRow>
+        {columns.map(({ displayName, dataName }, index) => {
+          if (displayName === '') {
+            return (
+              <TableCell
+                key={index}
+                align={index === 0 ? 'inherit' : align || 'inherit'}
+              />
+            )
+          }
+
+          return (
+            <TableCell
+              key={index}
+              align={index === 0 ? 'inherit' : align || 'inherit'}
+            >
+              <TableSortLabel
+                direction={orderDirection}
+                active={orderColumn === dataName}
+                onClick={() => onRequestSort(dataName)}
+              >
+                {' '}
+                {displayName}
+              </TableSortLabel>
+            </TableCell>
+          )
+        })}
+      </TableRow>
+    </TableHead>
+  )
+}
+
+export default SortedTableHead

--- a/client/Components/_shared/Timer.js
+++ b/client/Components/_shared/Timer.js
@@ -25,7 +25,7 @@ const Timer = ({
             : totalSecondsLeft - 1
           setTotalSecondsLeft(newTotalSecondsLeft)
         }, 1000)
-      } else if (totalSecondsLeft === 0 && action) {
+      } else if (totalSecondsLeft <= 0 && action) {
         action(...args)
       }
     }

--- a/client/store/shared-actions.js
+++ b/client/store/shared-actions.js
@@ -58,11 +58,19 @@ export const openStretchProcessThunk = (
       .then(({ data }) => {
         dispatch(updateCohortStretch(cohortStretchId, data))
         dispatch(startStretchTimer(data))
+        setTimeout(() => {
+          dispatch(closeStretchProcess(data.id))
+        }, stretch.minutes * 1000 * 60)
       })
   }
 }
 
-const closeStretchesOverdue = (cohortStretch, stretch, dispatch) => {
+const peformActionOnopenStretchesOnPageLoad = (
+  cohortStretch,
+  stretch,
+  dispatch,
+  type
+) => {
   const totalSecondsLeft =
     stretch.minutes * 60 -
     moment
@@ -75,6 +83,13 @@ const closeStretchesOverdue = (cohortStretch, stretch, dispatch) => {
         status: 'closed'
       })
     )
+  }
+  if (type === 'admin') {
+    return setTimeout(() => {
+      dispatch(closeStretchProcess(cohortStretch.id))
+    }, 1000 * totalSecondsLeft)
+  } else {
+    return true
   }
 }
 
@@ -104,7 +119,12 @@ export const loadAdminRelatedDataThunk = adminId => {
       return Promise.all(
         openCohortStretches.map(cohortStretch => {
           const stretch = stretches.find(s => s.id === cohortStretch.stretchId)
-          return closeStretchesOverdue(cohortStretch, stretch, dispatch)
+          return peformActionOnopenStretchesOnPageLoad(
+            cohortStretch,
+            stretch,
+            dispatch,
+            'admin'
+          )
         })
       )
     })
@@ -135,7 +155,12 @@ export const loadStudentRelatedDataThunk = studentId => {
       return Promise.all(
         openCohortStretches.map(cohortStretch => {
           const stretch = stretches.find(s => s.id === cohortStretch.stretchId)
-          return closeStretchesOverdue(cohortStretch, stretch, dispatch)
+          return peformActionOnopenStretchesOnPageLoad(
+            cohortStretch,
+            stretch,
+            dispatch,
+            'student'
+          )
         })
       )
     })

--- a/client/store/socket/Socket.js
+++ b/client/store/socket/Socket.js
@@ -6,6 +6,7 @@ import {
   addReceivedStretchAnswer,
   replaceStretchAnswer
 } from '../stretch-answers/actions'
+import { addStretch } from '../stretches/actions'
 import { generateFlashMessageId } from '../../utilityfunctions'
 
 class Socket {
@@ -51,6 +52,10 @@ class Socket {
           this.generateFlashMessageObjectForRatedAnswer(updatedStretchAnswer)
         )
       )
+    })
+
+    this.socket.on('receivedNewStretch', newStretch => {
+      this.storeAPI.dispatch(addStretch(newStretch, false))
     })
   }
 
@@ -144,6 +149,10 @@ class Socket {
 
   sendAnswerRating(updatedStretchAnswer) {
     this.socket.emit('answerRated', updatedStretchAnswer)
+  }
+
+  sendNewStretch(newStretch) {
+    this.socket.emit('stretchCreated', newStretch)
   }
 }
 

--- a/client/store/socket/middleware.js
+++ b/client/store/socket/middleware.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import Socket from './Socket'
 import { GET_USER_DETAILS, LOGOUT } from '../auth/actions'
 import { CREATE_COMMENT } from '../comments/actions'
@@ -6,6 +7,7 @@ import {
   CREATE_STRETCH_ANSWER,
   UPDATE_STRETCH_ANSWER
 } from '../stretch-answers/actions'
+import { CREATE_STRETCH } from '../stretches/actions'
 
 const socketMiddleware = storeAPI => {
   let socket
@@ -29,6 +31,11 @@ const socketMiddleware = storeAPI => {
       case UPDATE_STRETCH_ANSWER:
         if (action.emit) {
           socket.sendAnswerRating(action.updatedStretchAnswer)
+        }
+        break
+      case CREATE_STRETCH:
+        if (action.emit) {
+          socket.sendNewStretch(action.newStretch)
         }
         break
       default:

--- a/client/store/stretches/actions.js
+++ b/client/store/stretches/actions.js
@@ -12,7 +12,11 @@ export const DELETE_STRETCH = 'DELETE_STRETCH'
 // Action creators
 
 const getStretches = stretches => ({ type: GET_STRETCHES, stretches })
-const addStretch = newStretch => ({ type: CREATE_STRETCH, newStretch })
+export const addStretch = (newStretch, emit) => ({
+  type: CREATE_STRETCH,
+  newStretch,
+  emit
+})
 const replaceStretch = updatedStretch => ({
   type: UPDATE_STRETCH,
   updatedStretch
@@ -33,7 +37,7 @@ export const getAllStretches = () => dispatch => {
 export const createStretch = newStretch => dispatch => {
   return axios
     .post('/api/stretches', newStretch)
-    .then(res => dispatch(addStretch(res.data)))
+    .then(res => dispatch(addStretch(res.data, true)))
 }
 
 export const updateStretch = updatedStretch => dispatch => {

--- a/client/utilityfunctions.js
+++ b/client/utilityfunctions.js
@@ -32,3 +32,13 @@ export const parseDateTime = datetime => {
     localDateTime.format('LL').split(',')[0]
   }`
 }
+
+export const sortData = (data, orderColumn, orderDirection) => {
+  return data.sort((a, b) => {
+    if (a[orderColumn] < b[orderColumn])
+      return orderDirection === 'desc' ? 1 : -1
+    if (a[orderColumn] > b[orderColumn])
+      return orderDirection === 'desc' ? -1 : 1
+    return 0
+  })
+}

--- a/server/socket.js
+++ b/server/socket.js
@@ -64,6 +64,10 @@ const socketFunction = socketServer => {
           .emit('receivedAnswerRating', updatedStretchAnswer)
       }
     })
+
+    socket.on('stretchCreated', newStretch => {
+      socket.broadcast.emit('receivedNewStretch', newStretch)
+    })
   })
 }
 


### PR DESCRIPTION
- refactored very large single cohort stretch tables file (Stretches tab when go to Single Cohort)
- created shared SortedTableHead component so can make any table have sortable columns headers and applied it to all tables of Stretches tab
- made table of Stretches tab be collapsible
- fixed bug where if admin creates stretch and then schedules it and opens it, if student hasn't refreshed page in that time, student side blows up
- fixed bug where student and admin timers can get really out of sync