### PR TITLE
Implementing Stretch Solutions + Partially Editable Editor

### DIFF
--- a/bin/seed.js
+++ b/bin/seed.js
@@ -133,7 +133,7 @@ const createCohortStretchObjects = (cohortIds, stretchIds) => {
 
       let cohortStretch = {
         status,
-        allowAnswersToBeRun: Math.random() <= 0.5,
+        allowAnswersToBeRun: Math.random() <= 1,
         solution: paragraph(),
         cohortId: cohortIds[j],
         stretchId: getRandomArrayEntry(stretchIdsTemp),

--- a/bin/seed.js
+++ b/bin/seed.js
@@ -100,7 +100,7 @@ const createStretchObjects = (userIds, categoryIds) => {
     let stretch = {
       title: words(),
       textPrompt: paragraph(),
-      codePrompt: `${paragraph()}\n \n/*your code below --------------------------------------------------------------*/`,
+      codePrompt: paragraph(),
       difficulty:
         Math.random() <= 0.7 ? getRandomArrayEntry([1, 2, 3, 4, 5]) : null,
       minutes: getRandomArrayEntry([1]),

--- a/client/Components/AdminController/AdminController.js
+++ b/client/Components/AdminController/AdminController.js
@@ -8,6 +8,7 @@ import StretchReviewView from '../StretchReviewView'
 import StudentClosedStretchView from '../SIngleClosedStretchViev'
 import StretchAnalytics from '../AdminAnalytics/StretchAnalytics'
 import CohortAnalytics from '../AdminAnalytics/CohortAnalytics'
+import CohortStretchCreation from '../CohortStretchCreation'
 
 class AdminController extends Component {
   render() {
@@ -33,6 +34,12 @@ class AdminController extends Component {
           render={routeProps => <SingleStretch mode="read" {...routeProps} />}
         />
 
+        <Route
+          exact
+          path="/admin/stretch/:stretchId/schedule"
+          component={CohortStretchCreation}
+        />
+
         {/* This route is JSBin-like classroom for admin to go over completed stretch */}
         <Route
           exact
@@ -49,18 +56,23 @@ class AdminController extends Component {
 
         {/* path to go to Admin stretch dashboard for a stretch  */}
 
-        <Route exact path="/admin/stretch/analytics/:id"
-          component={StretchAnalytics} />
+        <Route
+          exact
+          path="/admin/stretch/analytics/:id"
+          component={StretchAnalytics}
+        />
 
-        <Route exact path="/admin/cohort/analytics/:id"
-          component={CohortAnalytics} />
+        <Route
+          exact
+          path="/admin/cohort/analytics/:id"
+          component={CohortAnalytics}
+        />
 
         <Route
           exact
           path="/admin/stretch/analytics/"
           component={StretchAnalytics}
         />
-
       </div>
     )
   }

--- a/client/Components/AdminStretches/AdminStretches.js
+++ b/client/Components/AdminStretches/AdminStretches.js
@@ -11,6 +11,8 @@ import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
 import Button from '@material-ui/core/Button'
 import Card from '@material-ui/core/Card'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
 import Typography from '@material-ui/core/Typography'
 import Tooltip from '@material-ui/core/Tooltip'
 
@@ -130,11 +132,16 @@ class AdminStretches extends Component {
 
   render() {
     const { searchTerm, currentTab } = this.state
-    const { stretches, cohorts, cohortStretches } = this.props
-    const currentStretches =
+    const { stretches, cohorts, cohortStretches, userDetails } = this.props
+    let currentStretches =
       this.state.currentStretches.length > 0
         ? this.state.currentStretches
         : stretches
+    currentStretches = currentStretches.filter(stretch => {
+      return currentTab === 0
+        ? stretch.authorId === userDetails.id
+        : stretch.authorId !== userDetails.id
+    })
 
     const allCategories = []
     stretches.map(stretch => allCategories.push(stretch.categoryName))
@@ -250,6 +257,21 @@ class AdminStretches extends Component {
           <Typography variant="h6" id="tableTitle">
             Stretch Inventory
           </Typography>
+
+          {
+            <Tabs
+              value={currentTab}
+              onChange={(event, tab) => this.setState({ currentTab: tab })}
+              indicatorColor="primary"
+              textColor="primary"
+              variant="fullWidth"
+              style={{ marginBottom: '2em' }}
+            >
+              <Tab label="Stretches Created By You" />
+              <Tab label="Other Stretches" />
+            </Tabs>
+          }
+
           <Table>
             <TableHead>
               <TableRow>
@@ -310,12 +332,14 @@ const mapStateToProps = ({
   categories,
   stretches,
   cohorts,
-  cohortStretches
+  cohortStretches,
+  userDetails
 }) => ({
   categories,
   stretches,
   cohorts,
-  cohortStretches
+  cohortStretches,
+  userDetails
 })
 
 const mapDispatchToProps = dispatch => {

--- a/client/Components/AdminStretches/AdminStretches.js
+++ b/client/Components/AdminStretches/AdminStretches.js
@@ -24,6 +24,7 @@ class AdminStretches extends Component {
       filterCategoryNames: [],
       selectedAuthor: '',
       currentStretches: [],
+      currentTab: 0,
 
       // The below two keys are for the StretchScheduler modal.
       modalIsOpen: false,
@@ -128,7 +129,7 @@ class AdminStretches extends Component {
     this.setState({ modalIsOpen: true, selectedStretch })
 
   render() {
-    const { searchTerm } = this.state
+    const { searchTerm, currentTab } = this.state
     const { stretches, cohorts, cohortStretches } = this.props
     const currentStretches =
       this.state.currentStretches.length > 0

--- a/client/Components/AdminStretches/AdminStretches.js
+++ b/client/Components/AdminStretches/AdminStretches.js
@@ -132,7 +132,13 @@ class AdminStretches extends Component {
 
   render() {
     const { searchTerm, currentTab } = this.state
-    const { stretches, cohorts, cohortStretches, userDetails } = this.props
+    const {
+      stretches,
+      cohorts,
+      cohortStretches,
+      userDetails,
+      history
+    } = this.props
     let currentStretches =
       this.state.currentStretches.length > 0
         ? this.state.currentStretches
@@ -311,7 +317,15 @@ class AdminStretches extends Component {
                       >
                         <Button
                           color="secondary"
-                          onClick={() => handleModalOpen(stretch)}
+                          onClick={() => {
+                            if (currentTab === 0) {
+                              handleModalOpen(stretch)
+                            } else {
+                              history.push(
+                                `/admin/stretch/${stretch.id}/schedule`
+                              )
+                            }
+                          }}
                         >
                           Schedule
                         </Button>

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -5,7 +5,6 @@ import configEditor from './configeditor'
 class AceEditor extends Component {
   constructor(props) {
     super(props)
-
     const { editorId } = this.props
     this.state = {
       editor: {},
@@ -27,11 +26,9 @@ class AceEditor extends Component {
       changeCodeToRun,
       readOnlyLinesRegEx
     } = this.props
-
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
     const selection = editorSession.selection
-    console.log('in config')
     this.configEditor(
       editor,
       { editorSession, selection },
@@ -62,8 +59,8 @@ class AceEditor extends Component {
     } = this.props
 
     if (prevProps.language !== language && language !== '') {
+      this.state.editor.setValue(initialCode || '')
       this.state.editorSession.setMode(`ace/mode/${language}`)
-      this.state.editor.setValue('')
     }
     if (prevProps.initialCode !== initialCode && initialCode !== '') {
       this.state.editor.setValue(initialCode)

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -24,7 +24,6 @@ class AceEditor extends Component {
       codeTargetName,
       readOnly,
       initialCode,
-      endBarrierRegEx,
       changeCodeToRun,
       readOnlyLinesRegEx
     } = this.props
@@ -32,6 +31,7 @@ class AceEditor extends Component {
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
     const selection = editorSession.selection
+    console.log('in config')
     this.configEditor(
       editor,
       { editorSession, selection },
@@ -39,7 +39,6 @@ class AceEditor extends Component {
         initialCode,
         editorTheme,
         language,
-        endBarrierRegEx,
         readOnlyLinesRegEx,
         readOnly: !!readOnly
       },
@@ -82,8 +81,7 @@ class AceEditor extends Component {
           readOnly: !!readOnly
         },
         { handleCodeChange, changeCodeToRun },
-        codeTargetName,
-        0
+        codeTargetName
       )
     }
     if (prevProps.editorTheme !== editorTheme) {

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -29,7 +29,8 @@ class AceEditor extends Component {
       initialCode,
       endBarrierRegEx,
       startBarrierData,
-      changeCodeToRun
+      changeCodeToRun,
+      jsxBarriers
     } = this.props
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
@@ -43,6 +44,7 @@ class AceEditor extends Component {
         language,
         endBarrierRegEx,
         startBarrierData,
+        jsxBarriers,
         readOnly: !!readOnly
       },
       { handleCodeChange, changeCodeToRun },
@@ -62,7 +64,8 @@ class AceEditor extends Component {
       endBarrierRegEx,
       startBarrierData,
       handleCodeChange,
-      changeCodeToRun
+      changeCodeToRun,
+      jsxBarriers
     } = this.props
 
     if (prevProps.language !== language && language !== '') {
@@ -90,6 +93,7 @@ class AceEditor extends Component {
           language,
           endBarrierRegEx,
           startBarrierData,
+          jsxBarriers,
           readOnly: !!readOnly
         },
         { handleCodeChange, changeCodeToRun },

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -1,12 +1,17 @@
+/* eslint-disable complexity */
 import React, { Component } from 'react'
-import configEditor from './configeditor'
+import configEditor, { excludeCodePromptInStretchAnswer } from './configeditor'
 
 class AceEditor extends Component {
   constructor(props) {
     super(props)
+    console.log(props)
     this.state = {
       editor: {},
       editorSession: {},
+      selection: {},
+      firstLineCanEdit: this.props.startBarrierData.numberOfLines || 0,
+      cursorPosition: {},
       editorId: this.props.editorId ? `ace-${this.props.editorId}` : 'ace'
     }
     this.configEditor = configEditor
@@ -19,38 +24,89 @@ class AceEditor extends Component {
       handleCodeChange,
       codeTargetName,
       readOnly,
-      initialCode
+      initialCode,
+      endBarrierRegEx,
+      startBarrierData
     } = this.props
 
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
+    const selection = editorSession.selection
     const codePromptRowCount = initialCode ? initialCode.split('\n').length : ''
     this.configEditor(
       editor,
-      editorSession,
-      { initialCode, editorTheme, language, readOnly: !!readOnly },
+      { editorSession, selection },
+      {
+        initialCode,
+        editorTheme,
+        language,
+        endBarrierRegEx,
+        startBarrierData,
+        readOnly: !!readOnly
+      },
       handleCodeChange,
       codeTargetName,
       codePromptRowCount
     )
 
-    this.setState({ editor, editorSession })
+    this.setState({ editor, editorSession, selection })
   }
 
   componentDidUpdate(prevProps) {
-    const { language, editorTheme, readOnly, initialCode } = this.props
+    const {
+      language,
+      editorTheme,
+      readOnly,
+      initialCode,
+      codeTargetName,
+      endBarrierRegEx,
+      startBarrierData,
+      handleCodeChange
+    } = this.props
     if (prevProps.language !== language && language !== '') {
       this.state.editorSession.setMode(`ace/mode/${language}`)
       this.state.editor.setValue('')
     }
+    if (
+      prevProps.startBarrierData.numberOfLines !==
+      startBarrierData.numberOfLines
+    ) {
+      this.setState({ firstLineCanEdit: startBarrierData.numberOfLines })
+    }
     if (prevProps.initialCode !== initialCode && initialCode !== '') {
       this.state.editor.setValue(initialCode)
+      this.configEditor(
+        this.state.editor,
+        {
+          editorSession: this.state.editorSession,
+          selection: this.state.selection
+        },
+        {
+          initialCode,
+          editorTheme,
+          language,
+          endBarrierRegEx,
+          startBarrierData,
+          readOnly: !!readOnly
+        },
+        handleCodeChange,
+        codeTargetName,
+        0
+      )
     }
     if (prevProps.editorTheme !== editorTheme) {
       this.state.editor.setTheme(`ace/theme/${editorTheme}`)
     }
     if (prevProps.readOnly !== readOnly) {
       this.state.editor.setReadOnly(readOnly)
+    }
+  }
+
+  componentWillUnmount() {
+    console.log('first')
+    if (typeof this.props.onUnmount === 'function') {
+      console.log('second')
+      this.props.onUnmount()
     }
   }
 

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -5,15 +5,12 @@ import configEditor from './configeditor'
 class AceEditor extends Component {
   constructor(props) {
     super(props)
-    console.log(props)
-    const { editorId, startBarrierData } = this.props
+
+    const { editorId } = this.props
     this.state = {
       editor: {},
       editorSession: {},
       selection: {},
-      firstLineCanEdit: startBarrierData
-        ? startBarrierData.numberOfLines || 0
-        : 0,
       editorId: editorId ? `ace-${editorId}` : 'ace'
     }
     this.configEditor = configEditor
@@ -28,10 +25,10 @@ class AceEditor extends Component {
       readOnly,
       initialCode,
       endBarrierRegEx,
-      startBarrierData,
       changeCodeToRun,
-      jsxBarriers
+      readOnlyLinesRegEx
     } = this.props
+
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
     const selection = editorSession.selection
@@ -43,8 +40,7 @@ class AceEditor extends Component {
         editorTheme,
         language,
         endBarrierRegEx,
-        startBarrierData,
-        jsxBarriers,
+        readOnlyLinesRegEx,
         readOnly: !!readOnly
       },
       { handleCodeChange, changeCodeToRun },
@@ -61,23 +57,14 @@ class AceEditor extends Component {
       readOnly,
       initialCode,
       codeTargetName,
-      endBarrierRegEx,
-      startBarrierData,
       handleCodeChange,
       changeCodeToRun,
-      jsxBarriers
+      readOnlyLinesRegEx
     } = this.props
 
     if (prevProps.language !== language && language !== '') {
       this.state.editorSession.setMode(`ace/mode/${language}`)
       this.state.editor.setValue('')
-    }
-    if (
-      startBarrierData &&
-      prevProps.startBarrierData.numberOfLines !==
-        startBarrierData.numberOfLines
-    ) {
-      this.setState({ firstLineCanEdit: startBarrierData.numberOfLines })
     }
     if (prevProps.initialCode !== initialCode && initialCode !== '') {
       this.state.editor.setValue(initialCode)
@@ -91,9 +78,7 @@ class AceEditor extends Component {
           initialCode,
           editorTheme,
           language,
-          endBarrierRegEx,
-          startBarrierData,
-          jsxBarriers,
+          readOnlyLinesRegEx,
           readOnly: !!readOnly
         },
         { handleCodeChange, changeCodeToRun },
@@ -106,12 +91,6 @@ class AceEditor extends Component {
     }
     if (prevProps.readOnly !== readOnly) {
       this.state.editor.setReadOnly(readOnly)
-    }
-  }
-
-  componentWillUnmount() {
-    if (typeof this.props.onUnmount === 'function') {
-      this.props.onUnmount()
     }
   }
 

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -1,18 +1,20 @@
 /* eslint-disable complexity */
 import React, { Component } from 'react'
-import configEditor, { excludeCodePromptInStretchAnswer } from './configeditor'
+import configEditor from './configeditor'
 
 class AceEditor extends Component {
   constructor(props) {
     super(props)
     console.log(props)
+    const { editorId, startBarrierData } = this.props
     this.state = {
       editor: {},
       editorSession: {},
       selection: {},
-      firstLineCanEdit: this.props.startBarrierData.numberOfLines || 0,
-      cursorPosition: {},
-      editorId: this.props.editorId ? `ace-${this.props.editorId}` : 'ace'
+      firstLineCanEdit: startBarrierData
+        ? startBarrierData.numberOfLines || 0
+        : 0,
+      editorId: editorId ? `ace-${editorId}` : 'ace'
     }
     this.configEditor = configEditor
   }
@@ -26,9 +28,9 @@ class AceEditor extends Component {
       readOnly,
       initialCode,
       endBarrierRegEx,
-      startBarrierData
+      startBarrierData,
+      changeCodeToRun
     } = this.props
-
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
     const selection = editorSession.selection
@@ -44,7 +46,7 @@ class AceEditor extends Component {
         startBarrierData,
         readOnly: !!readOnly
       },
-      handleCodeChange,
+      { handleCodeChange, changeCodeToRun },
       codeTargetName,
       codePromptRowCount
     )
@@ -61,15 +63,18 @@ class AceEditor extends Component {
       codeTargetName,
       endBarrierRegEx,
       startBarrierData,
-      handleCodeChange
+      handleCodeChange,
+      changeCodeToRun
     } = this.props
+
     if (prevProps.language !== language && language !== '') {
       this.state.editorSession.setMode(`ace/mode/${language}`)
       this.state.editor.setValue('')
     }
     if (
+      startBarrierData &&
       prevProps.startBarrierData.numberOfLines !==
-      startBarrierData.numberOfLines
+        startBarrierData.numberOfLines
     ) {
       this.setState({ firstLineCanEdit: startBarrierData.numberOfLines })
     }
@@ -89,7 +94,7 @@ class AceEditor extends Component {
           startBarrierData,
           readOnly: !!readOnly
         },
-        handleCodeChange,
+        { handleCodeChange, changeCodeToRun },
         codeTargetName,
         0
       )
@@ -103,9 +108,7 @@ class AceEditor extends Component {
   }
 
   componentWillUnmount() {
-    console.log('first')
     if (typeof this.props.onUnmount === 'function') {
-      console.log('second')
       this.props.onUnmount()
     }
   }

--- a/client/Components/CodeEditor/CodeEditor.js
+++ b/client/Components/CodeEditor/CodeEditor.js
@@ -34,7 +34,6 @@ class AceEditor extends Component {
     const editor = ace.edit(this.state.editorId)
     const editorSession = editor.getSession()
     const selection = editorSession.selection
-    const codePromptRowCount = initialCode ? initialCode.split('\n').length : ''
     this.configEditor(
       editor,
       { editorSession, selection },
@@ -47,8 +46,7 @@ class AceEditor extends Component {
         readOnly: !!readOnly
       },
       { handleCodeChange, changeCodeToRun },
-      codeTargetName,
-      codePromptRowCount
+      codeTargetName
     )
 
     this.setState({ editor, editorSession, selection })

--- a/client/Components/CodeEditor/CommonCodeSection.js
+++ b/client/Components/CodeEditor/CommonCodeSection.js
@@ -90,7 +90,6 @@ class CommonCodeSection extends Component {
         ...jsxBarriers.regExToCheck
       }
     }
-    console.log(codeTargetName)
 
     return (
       <div>

--- a/client/Components/CodeEditor/CommonCodeSection.js
+++ b/client/Components/CodeEditor/CommonCodeSection.js
@@ -1,0 +1,150 @@
+import React, { Component } from 'react'
+import axios from 'axios'
+import { connect } from 'react-redux'
+import functions from './functions'
+const { runCode, clearCodeResults } = functions
+import ThemeSelector from './ThemeSelector'
+import RunCodeButton from './RunCodeButton'
+import ClearCodeResultsButton from './ClearCodeResultsButton'
+import CommonEditorAndOutput from './CommonEditorAndOutput'
+
+import Grid from '@material-ui/core/Grid'
+import { codeSectionStyles } from '../StretchReviewView/styles'
+
+class CommonCodeSection extends Component {
+  constructor() {
+    super()
+    this.state = {
+      editorTheme: 'monokai',
+      codeToRun: '',
+      codeResponse: '',
+      codeError: '',
+      fileGenerated: false
+    }
+    this.runCodeBinded = runCode.bind(this)
+    this.clearCodeResultsBinded = clearCodeResults.bind(this)
+  }
+
+  componentDidMount() {
+    this.removeTemporaryUserFiles()
+  }
+
+  componentWillUnmount() {
+    this.removeTemporaryUserFiles()
+  }
+
+  removeTemporaryUserFiles() {
+    const {
+      stretch: { language },
+      fileName
+    } = this.props
+    if (language === 'jsx') {
+      axios.delete(`/api/code/${fileName}`)
+    }
+  }
+
+  handleChange = ({ target }) => {
+    this.setState({ [target.name]: target.value })
+  }
+
+  render() {
+    const {
+      editorTheme,
+      codeResponse,
+      codeError,
+      fileGenerated,
+      codeToRun
+    } = this.state
+    const { runCodeBinded, clearCodeResultsBinded, handleChange } = this
+    const {
+      handleCodeChange,
+      //readOnlyLinesRegEx,
+      //jsxBarriers,
+      codeTargetName,
+      fileName,
+      stretch: { language, codePrompt }
+      // cohortStretchId,
+      //userDetails
+    } = this.props
+
+    const codeCommentWord =
+      codeTargetName === 'studentAnswerRun' ? 'answer' : 'solution'
+
+    let readOnlyLinesRegEx = {
+      solutionStart: `Write your ${codeCommentWord} below this line`
+    }
+
+    const jsxBarriers = {
+      string: `// Write your ${codeCommentWord} above this line\n\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))`,
+      regExToCheck: {
+        solutionEnd: `Write your ${codeCommentWord} above this line`,
+        render: /ReactDOM.render\(<App \/>,/,
+        string: /\/\/ Return component to render inside App component/,
+        appComponentStart: /const App = \(\) => {/,
+        appComponentEnd: /} \/\/ End Of App component/
+      }
+    }
+    if (language === 'jsx') {
+      readOnlyLinesRegEx = {
+        ...readOnlyLinesRegEx,
+        ...jsxBarriers.regExToCheck
+      }
+    }
+    console.log(codeTargetName)
+
+    return (
+      <div>
+        <Grid container>
+          <Grid item xs={6}>
+            <ThemeSelector {...{ editorTheme, handleChange }} />
+          </Grid>
+          <Grid item xs={6}>
+            <Grid container style={codeSectionStyles.controls}>
+              <Grid item xs={12}>
+                <RunCodeButton
+                  color="primary"
+                  runCode={runCodeBinded}
+                  postPayload={{
+                    code: codeToRun,
+                    language,
+                    fileName: language === 'javascript' ? '' : fileName
+                  }}
+                />
+                <ClearCodeResultsButton
+                  color="secondary"
+                  clearCodeResults={clearCodeResultsBinded}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+        <CommonEditorAndOutput
+          //codeTargetName="studentAnswerRun"
+          fileName={`/temp/${fileName}.html`}
+          initialCode={`// Code Prompt\n\n/*${codePrompt}*/\n\n// Write your ${codeCommentWord} below this line --------------------------------\n\n${
+            language === 'jsx' ? jsxBarriers.string : ''
+          }`}
+          // handleCodeChange={handleCodeChange}
+          changeCodeToRun={codeToRun => this.setState({ codeToRun })}
+          {...{
+            handleCodeChange,
+            language,
+            editorTheme,
+            fileGenerated,
+            codeResponse,
+            codeError,
+            codeTargetName,
+            readOnlyLinesRegEx
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = ({ stretches, userDetails }, { stretchId }) => ({
+  stretch: stretches.find(s => s.id === stretchId),
+  userDetails
+})
+
+export default connect(mapStateToProps)(CommonCodeSection)

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -18,7 +18,8 @@ const CommonEditorAndOutput = props => {
     handleCodeChange,
     changeCodeToRun,
     readOnlyLinesRegEx,
-    readOnly
+    readOnly,
+    editorId
   } = props
   return (
     <Grid container>
@@ -32,7 +33,8 @@ const CommonEditorAndOutput = props => {
             changeCodeToRun,
             language,
             readOnlyLinesRegEx,
-            readOnly
+            readOnly,
+            editorId
           }}
         />
       </Grid>

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -18,7 +18,8 @@ const CommonEditorAndOutput = props => {
     handleCodeChange,
     onUnmount,
     endBarrierRegEx,
-    startBarrierData
+    startBarrierData,
+    changeCodeToRun
   } = props
   return (
     <Grid container>
@@ -29,6 +30,7 @@ const CommonEditorAndOutput = props => {
             initialCode,
             editorTheme,
             handleCodeChange,
+            changeCodeToRun,
             language,
             onUnmount,
             endBarrierRegEx,

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -16,11 +16,9 @@ const CommonEditorAndOutput = props => {
     codeResponse,
     codeError,
     handleCodeChange,
-    onUnmount,
-    endBarrierRegEx,
-    startBarrierData,
     changeCodeToRun,
-    jsxBarriers
+    readOnlyLinesRegEx,
+    readOnly
   } = props
   return (
     <Grid container>
@@ -33,10 +31,8 @@ const CommonEditorAndOutput = props => {
             handleCodeChange,
             changeCodeToRun,
             language,
-            onUnmount,
-            endBarrierRegEx,
-            startBarrierData,
-            jsxBarriers
+            readOnlyLinesRegEx,
+            readOnly
           }}
         />
       </Grid>

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -15,7 +15,10 @@ const CommonEditorAndOutput = props => {
     fileGenerated,
     codeResponse,
     codeError,
-    handleCodeChange
+    handleCodeChange,
+    onUnmount,
+    endBarrierRegEx,
+    startBarrierData
   } = props
   return (
     <Grid container>
@@ -26,7 +29,10 @@ const CommonEditorAndOutput = props => {
             initialCode,
             editorTheme,
             handleCodeChange,
-            language
+            language,
+            onUnmount,
+            endBarrierRegEx,
+            startBarrierData
           }}
         />
       </Grid>

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -19,7 +19,8 @@ const CommonEditorAndOutput = props => {
     onUnmount,
     endBarrierRegEx,
     startBarrierData,
-    changeCodeToRun
+    changeCodeToRun,
+    jsxBarriers
   } = props
   return (
     <Grid container>
@@ -34,7 +35,8 @@ const CommonEditorAndOutput = props => {
             language,
             onUnmount,
             endBarrierRegEx,
-            startBarrierData
+            startBarrierData,
+            jsxBarriers
           }}
         />
       </Grid>

--- a/client/Components/CodeEditor/CommonEditorAndOutput.js
+++ b/client/Components/CodeEditor/CommonEditorAndOutput.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import Typography from '@material-ui/core/Typography'
+import CodeEditor from './CodeEditor'
+import CodeOutput from './CodeOutput'
+import { codeSectionStyles } from './styles'
+
+const CommonEditorAndOutput = props => {
+  const {
+    codeTargetName,
+    language,
+    initialCode,
+    editorTheme,
+    fileName,
+    fileGenerated,
+    codeResponse,
+    codeError,
+    handleCodeChange
+  } = props
+  return (
+    <Grid container>
+      <Grid item xs={6}>
+        <CodeEditor
+          {...{
+            codeTargetName,
+            initialCode,
+            editorTheme,
+            handleCodeChange,
+            language
+          }}
+        />
+      </Grid>
+      <Grid item xs={6}>
+        {language === 'jsx' && (
+          <Typography
+            variant="subtitle2"
+            style={codeSectionStyles.outputLabels}
+          >
+            JSX Rendering
+          </Typography>
+        )}
+
+        {language === 'jsx' && (
+          <iframe
+            src={fileGenerated ? fileName : ''}
+            style={codeSectionStyles.iframe}
+          />
+        )}
+        {language === 'jsx' && (
+          <Typography
+            variant="subtitle2"
+            style={codeSectionStyles.outputLabels}
+          >
+            Console
+          </Typography>
+        )}
+        <CodeOutput
+          codeResponse={codeResponse}
+          codeError={codeError}
+          minHeight={`${language === 'jsx' ? '10' : '23'}rem`}
+        />
+      </Grid>
+    </Grid>
+  )
+}
+
+export default CommonEditorAndOutput

--- a/client/Components/CodeEditor/configeditor.js
+++ b/client/Components/CodeEditor/configeditor.js
@@ -113,11 +113,7 @@ const getStudentAnswerPortion = (
     .join('')
 }
 
-const studentAnswerCheckLineReadOnly = (
-  readOnlyLinesRegEx,
-  editor,
-  currentCode
-) => {
+const checkIfCursorInCodePrompt = (readOnlyLinesRegEx, editor, currentCode) => {
   let lastLineCodePrompt = 0
   for (let i = 0; i < currentCode.length; ++i) {
     if (currentCode[i].search(readOnlyLinesRegEx.solutionStart) >= 0) {
@@ -177,8 +173,11 @@ const configEditor = function(
       readOnlyLinesRegEx !== null &&
       Object.keys(readOnlyLinesRegEx).length
     ) {
-      if (codeTargetName.startsWith('studentAnswer')) {
-        studentAnswerCheckLineReadOnly(
+      if (
+        codeTargetName.startsWith('studentAnswer') ||
+        codeTargetName === 'cohortStretchCreation'
+      ) {
+        checkIfCursorInCodePrompt(
           readOnlyLinesRegEx,
           editor,
           currentCode.split('\n')
@@ -204,16 +203,20 @@ const configEditor = function(
       target: {
         name: codeTargetName,
         value: `${
-          codeTargetName.startsWith('studentAnswer')
+          codeTargetName.startsWith('studentAnswer') ||
+          codeTargetName === 'cohortStretchCreation'
             ? getStudentAnswerPortion(editorSession, readOnlyLinesRegEx)
             : editorSession.getValue()
         }`
       }
     })
     if (
-      ['authorSolution', 'studentAnswerRun', 'createStretch'].includes(
-        codeTargetName
-      )
+      [
+        'authorSolution',
+        'studentAnswerRun',
+        'createStretch',
+        'cohortStretchCreation'
+      ].includes(codeTargetName)
     ) {
       changeCodeToRun(editorSession.getValue())
     }

--- a/client/Components/CodeEditor/configeditor.js
+++ b/client/Components/CodeEditor/configeditor.js
@@ -48,7 +48,7 @@ const configEditor = function(
   editor,
   { editorSession, selection },
   userOptions,
-  handleCodeChange,
+  { handleCodeChange, changeCodeToRun },
   codeTargetName,
   codePromptRowCount
 ) {
@@ -76,46 +76,24 @@ const configEditor = function(
   })
 
   selection.on('changeCursor', () => {
-    const currentCode = /* initialCode ||*/ editorSession.getValue()
-    if (editor.getCursorPosition().row <= this.state.firstLineCanEdit) {
-      editor.setReadOnly(true)
-    } else {
-      editor.setReadOnly(false)
-    }
-
-    if (codeTargetName === 'authorSolution' && currentCode) {
-      console.log('current code split', currentCode.split('\n'))
-      console.log('my cursor positon', editor.getCursorPosition().row)
-      const rg = currentCode.split('\n')[editor.getCursorPosition().row]
-      console.log('rg', rg)
-      if (
-        rg &&
-        rg.search('Write the solution above this line-----------------') >= 0
-      ) {
+    if (endBarrierRegEx) {
+      const currentCode = editorSession.getValue()
+      if (editor.getCursorPosition().row <= this.state.firstLineCanEdit) {
         editor.setReadOnly(true)
+      } else {
+        editor.setReadOnly(false)
       }
-      /*currentCode.split('\n').forEach((row, idx) => {
-        console.log('for loop')
-        console.log(row)
-        console.log(
-          row.search('Write the solution above this line-----------------') >= 0
-        )
-        console.log(idx, editor.getCursorPosition().row)
-        if (
-          row.search(endBarrierRegEx) >= 0 &&
-          idx === editor.getCursorPosition().row
-        ) {
+
+      if (
+        ['studentAnswer', 'authorSolution'].includes(codeTargetName) &&
+        currentCode
+      ) {
+        const rg = currentCode.split('\n')[editor.getCursorPosition().row]
+        if (rg && rg.search(endBarrierRegEx) >= 0) {
           editor.setReadOnly(true)
         }
-      })*/
+      }
     }
-
-    console.log('cursorposition', editor.getCursorPosition().row)
-    console.log('irsliencanedit', this.state.firstLineCanEdit)
-
-    this.setState({ cursorPosition: editor.getCursorPosition() }, () =>
-      console.log(this.state)
-    )
   })
   editorSession.on('change', () => {
     addClosingCurlyBracket(editor, editorSession)
@@ -123,7 +101,7 @@ const configEditor = function(
       target: {
         name: codeTargetName,
         value: `${
-          ['codeAnswer', 'authorSolution'].includes(codeTargetName)
+          ['studentAnswer', 'authorSolution'].includes(codeTargetName)
             ? excludeCodePromptInStretchAnswer(
                 { codePromptRowCount, editor },
                 editorSession,
@@ -135,6 +113,9 @@ const configEditor = function(
         }`
       }
     })
+    if (['studentAnswer', 'authorSolution'].includes(codeTargetName)) {
+      changeCodeToRun(editorSession.getValue())
+    }
   })
 }
 

--- a/client/Components/CodeEditor/configeditor.js
+++ b/client/Components/CodeEditor/configeditor.js
@@ -25,12 +25,17 @@ const checkIfDeletingLineBetweenTwoReadOnlyLines = (
   const cursorRow = editor.getCursorPosition().row
   const codeSplitByLine = editorSession.getValue().split('\n')
   let linesReadOnlyCount = 0
+  // eslint-disable-next-line guard-for-in
   for (let key in readOnlyLinesRegEx) {
-    if (cursorRow === codeSplitByLine.length - 1) {
-      ++linesReadOnlyCount
-    } else {
-      const currentLineReadOnlyForCurrentRegEx =
-        codeSplitByLine[cursorRow].search(readOnlyLinesRegEx[key]) >= 0
+    const currentLineReadOnlyForCurrentRegEx =
+      codeSplitByLine[cursorRow].search(readOnlyLinesRegEx[key]) >= 0
+    if (
+      cursorRow === codeSplitByLine.length - 1 &&
+      currentLineReadOnlyForCurrentRegEx
+    ) {
+      editorSession.insert({ row: cursorRow + 1, column: 0 }, '\n')
+      return
+    } else if (cursorRow < codeSplitByLine.length - 1) {
       const nextLineReadOnlyForCurrentRegEx =
         codeSplitByLine[cursorRow + 1].search(readOnlyLinesRegEx[key]) >= 0
       if (

--- a/client/Components/CodeEditor/functions.js
+++ b/client/Components/CodeEditor/functions.js
@@ -16,7 +16,7 @@ const runCode = function(postPayload) {
                 codeError: '',
                 fileGenerated: true
               }
-        this.setState(stateObject, () => console.log(this.state))
+        this.setState(stateObject)
       })
       .catch(({ response: { data } }) => {
         this.setState({ codeError: data, codeResponse: '' })

--- a/client/Components/CodeEditor/index.js
+++ b/client/Components/CodeEditor/index.js
@@ -4,12 +4,14 @@ import RunCodeButton from './RunCodeButton'
 import ThemeSelector from './ThemeSelector'
 import CodeOutput from './CodeOutput'
 import functions from './functions'
+import CommonEditorAndOutput from './CommonEditorAndOutput'
 
 export const AuxillaryComponents = {
   ClearCodeResultsButton,
   RunCodeButton,
   ThemeSelector,
-  CodeOutput
+  CodeOutput,
+  CommonEditorAndOutput
 }
 export const codeEditorFunctions = functions
 

--- a/client/Components/CodeEditor/index.js
+++ b/client/Components/CodeEditor/index.js
@@ -5,13 +5,15 @@ import ThemeSelector from './ThemeSelector'
 import CodeOutput from './CodeOutput'
 import functions from './functions'
 import CommonEditorAndOutput from './CommonEditorAndOutput'
+import CommonCodeSection from './CommonCodeSection'
 
 export const AuxillaryComponents = {
   ClearCodeResultsButton,
   RunCodeButton,
   ThemeSelector,
   CodeOutput,
-  CommonEditorAndOutput
+  CommonEditorAndOutput,
+  CommonCodeSection
 }
 export const codeEditorFunctions = functions
 

--- a/client/Components/CodeEditor/styles.js
+++ b/client/Components/CodeEditor/styles.js
@@ -24,3 +24,12 @@ export const buttonsStyles = {
     marginBottom: '10px'
   }
 }
+
+export const codeSectionStyles = {
+  outputLabels: {
+    textAlign: 'center'
+  },
+  iframe: {
+    width: '100%'
+  }
+}

--- a/client/Components/CohortStretchCreation/CohortStretchCreation.js
+++ b/client/Components/CohortStretchCreation/CohortStretchCreation.js
@@ -1,4 +1,4 @@
-import React, { useState, Component } from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
 import { createCohortStretch } from '../../store/cohort-stretches/actions'
 

--- a/client/Components/CohortStretchCreation/CohortStretchCreation.js
+++ b/client/Components/CohortStretchCreation/CohortStretchCreation.js
@@ -1,0 +1,164 @@
+import React, { useState, Component } from 'react'
+import { connect } from 'react-redux'
+import { createCohortStretch } from '../../store/cohort-stretches/actions'
+
+import Grid from '@material-ui/core/Grid'
+import DateAndTimePicker from '../_shared/DateAndTimePicker'
+import CohortSelect from '../_shared/CohortSelect'
+import CodeEditor, { AuxillaryComponents } from '../CodeEditor'
+const { CommonCodeSection } = AuxillaryComponents
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import { ControlStyles } from '../SingleStretch/styles'
+import GeneralInfo from '../SingleStretch/GeneralInfo'
+
+const CohortStretchCreation = ({
+  stretch,
+  userDetails,
+  createCohortStretch,
+  history
+}) => {
+  if (!stretch) return <div>Data still loading</div>
+
+  let [scheduledDate, setScheduledDate] = useState(new Date())
+  let [selectedCohortId, setSelectedCohortId] = useState('')
+  let [allowAnswersToBeRun, setAllowAnswersToBeRun] = useState(false)
+  let [alternateSolution, setAlternateSolution] = useState('')
+  let [saveAlternateSolution, setSaveAlternateSolution] = useState(false)
+  const { authorSolution, language } = stretch
+
+  const scheduleStretch = () => {
+    return createCohortStretch({
+      status: 'scheduled',
+      scheduledDate,
+      allowAnswersToBeRun,
+      stretchId: stretch.id,
+      cohortId: selectedCohortId,
+      cohortSolution: saveAlternateSolution ? alternateSolution : null
+    }).then(() => history.push(`/admin/cohort/${selectedCohortId}`))
+  }
+
+  return (
+    <Grid container>
+      <Grid container style={{ ...ControlStyles.root, textAlign: 'right' }}>
+        <Grid item xs={12}>
+          <div>
+            <Button
+              variant="contained"
+              onClick={scheduleStretch}
+              color="primary"
+            >
+              Schedule
+            </Button>
+          </div>
+        </Grid>
+      </Grid>
+      <Grid item xs={12}>
+        <GeneralInfo attributes={{ ...stretch, mode: 'read' }} />
+      </Grid>
+      <Grid item xs={12}>
+        <Typography variant="caption" style={{ color: 'red' }}>
+          * any cohorts in red are ones you have already used stretch in
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <Grid container>
+          <Grid item xs={6}>
+            <DateAndTimePicker
+              name="scheduledDate"
+              label="Scheduled Date"
+              value={scheduledDate}
+              handleChange={setScheduledDate}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <CohortSelect
+              cohortId={selectedCohortId}
+              handleChange={({ target: { value } }) =>
+                setSelectedCohortId(value)
+              }
+              stretchId={stretch.id}
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+
+      <Grid
+        item
+        xs={12}
+        style={{ borderBottom: '2px solid lightGrey', marginBottom: '15px' }}
+      >
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={allowAnswersToBeRun}
+              onChange={({ target }) => setAllowAnswersToBeRun(target.checked)}
+              color="primary"
+            />
+          }
+          label="Check this box if you want to allow students to run code while completing the stretch"
+        />
+      </Grid>
+
+      <Grid item xs={12}>
+        <Typography variant="subtitle1" style={{ fontSize: '1.2rem' }}>
+          Author Solution
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <CodeEditor
+          readOnly={true}
+          initialCode={authorSolution}
+          language={language}
+          editorTheme="monokai"
+          editorId="authorSolution"
+        />
+      </Grid>
+
+      <Grid item xs={12}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={saveAlternateSolution}
+              onChange={({ target }) =>
+                setSaveAlternateSolution(target.checked)
+              }
+              color="primary"
+            />
+          }
+          label="Check this box if you want to to use your solution below instead of author's solution"
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <CommonCodeSection
+          handleCodeChange={({ target: { value } }) =>
+            setAlternateSolution(value)
+          }
+          codeTargetName="cohortStretchCreation"
+          stretchId={stretch.id}
+          fileName={`file-${userDetails.id}-${stretch.id}`}
+          editorId="cohortSolution"
+        />
+      </Grid>
+    </Grid>
+  )
+}
+
+const mapStateToProps = (
+  { stretches, userDetails },
+  {
+    match: {
+      params: { stretchId }
+    }
+  }
+) => ({ stretch: stretches.find(s => s.id === stretchId), userDetails })
+
+const mapDispatchToProps = dispatch => ({
+  createCohortStretch: data => dispatch(createCohortStretch(data))
+})
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CohortStretchCreation)

--- a/client/Components/CohortStretchCreation/index.js
+++ b/client/Components/CohortStretchCreation/index.js
@@ -1,0 +1,3 @@
+import CohortStretchCreation from './CohortStretchCreation'
+
+export default CohortStretchCreation

--- a/client/Components/OpenStretchView/CodeSectionNoRun.js
+++ b/client/Components/OpenStretchView/CodeSectionNoRun.js
@@ -10,14 +10,10 @@ const CodeSectionNoRun = ({
 }) => {
   const [editorTheme, setEditorTheme] = useState('monokai')
 
-  const startBarrierString = `${codePrompt}\n\n// Write your answer below this line --------------------------------\n`
-  const startBarrierData = {
-    length: startBarrierString.length,
-    numberOfLines: startBarrierString.split('\n').length - 2
+  const readOnlyLinesRegEx = {
+    solutionStart: /\/\/ Write your answer below this line --------------------------------/
   }
-  const endBarrierString = `// Write your answer above this line-----------------\n `
-  const endBarrierRegEx = /\/\/ Write your answer above this line-----------------/
-  const solutionAnnonated = `${startBarrierString}\n${endBarrierString}`
+
   return (
     <Grid container>
       <Grid item xs={12}>
@@ -29,9 +25,9 @@ const CodeSectionNoRun = ({
       <Grid item xs={12}>
         <CodeEditor
           codeTargetName="studentAnswerNoRun"
-          initialCode={solutionAnnonated}
+          initialCode={`// Code Prompt\n\n${codePrompt}\n\n// Write your answer below this line --------------------------------\n`}
           handleCodeChange={({ target }) => setStretchAnswer(target.value)}
-          {...{ language, editorTheme, startBarrierData, endBarrierRegEx }}
+          {...{ language, editorTheme, readOnlyLinesRegEx }}
         />
       </Grid>
     </Grid>

--- a/client/Components/OpenStretchView/CodeSectionNoRun.js
+++ b/client/Components/OpenStretchView/CodeSectionNoRun.js
@@ -9,6 +9,15 @@ const CodeSectionNoRun = ({
   stretch: { language, codePrompt }
 }) => {
   const [editorTheme, setEditorTheme] = useState('monokai')
+
+  const startBarrierString = `${codePrompt}\n\n// Write your answer below this line --------------------------------\n`
+  const startBarrierData = {
+    length: startBarrierString.length,
+    numberOfLines: startBarrierString.split('\n').length - 2
+  }
+  const endBarrierString = `// Write your answer above this line-----------------\n `
+  const endBarrierRegEx = /\/\/ Write your answer above this line-----------------/
+  const solutionAnnonated = `${startBarrierString}\n${endBarrierString}`
   return (
     <Grid container>
       <Grid item xs={12}>
@@ -19,11 +28,10 @@ const CodeSectionNoRun = ({
       </Grid>
       <Grid item xs={12}>
         <CodeEditor
-          codeTargetName="code"
-          initialCode={codePrompt}
-          editorTheme={editorTheme}
+          codeTargetName="studentAnswerNoRun"
+          initialCode={solutionAnnonated}
           handleCodeChange={({ target }) => setStretchAnswer(target.value)}
-          language={language}
+          {...{ language, editorTheme, startBarrierData, endBarrierRegEx }}
         />
       </Grid>
     </Grid>

--- a/client/Components/OpenStretchView/CodeSectionRun.js
+++ b/client/Components/OpenStretchView/CodeSectionRun.js
@@ -1,20 +1,16 @@
 import React, { Component } from 'react'
 import axios from 'axios'
 import { connect } from 'react-redux'
-import CodeEditor, {
-  AuxillaryComponents,
-  codeEditorFunctions
-} from '../CodeEditor'
+import { AuxillaryComponents, codeEditorFunctions } from '../CodeEditor'
 const { runCode, clearCodeResults } = codeEditorFunctions
 const {
   ThemeSelector,
   RunCodeButton,
   ClearCodeResultsButton,
-  CodeOutput
+  CommonEditorAndOutput
 } = AuxillaryComponents
 
 import Grid from '@material-ui/core/Grid'
-import Typography from '@material-ui/core/Typography'
 import { codeSectionStyles } from '../StretchReviewView/styles'
 
 class CodeSectionRun extends Component {
@@ -63,6 +59,7 @@ class CodeSectionRun extends Component {
       cohortStretchId,
       userDetails
     } = this.props
+    console.log(stretchAnswer)
     return (
       <div>
         <Grid container>
@@ -92,51 +89,13 @@ class CodeSectionRun extends Component {
             </Grid>
           </Grid>
         </Grid>
-        <Grid container>
-          <Grid item xs={6}>
-            <CodeEditor
-              codeTargetName="codeAnswer"
-              initialCode={codePrompt}
-              editorTheme={editorTheme}
-              handleCodeChange={({ target }) => setStretchAnswer(target.value)}
-              language={language}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            {language === 'jsx' && (
-              <Typography
-                variant="subtitle2"
-                style={codeSectionStyles.outputLabels}
-              >
-                JSX Rendering
-              </Typography>
-            )}
-
-            {language === 'jsx' && (
-              <iframe
-                src={
-                  fileGenerated
-                    ? `/temp/file-${cohortStretchId}-${userDetails.id}.html`
-                    : ''
-                }
-                style={codeSectionStyles.iframe}
-              />
-            )}
-            {language === 'jsx' && (
-              <Typography
-                variant="subtitle2"
-                style={codeSectionStyles.outputLabels}
-              >
-                Console
-              </Typography>
-            )}
-            <CodeOutput
-              codeResponse={codeResponse}
-              codeError={codeError}
-              minHeight={`${language === 'jsx' ? '10' : '23'}rem`}
-            />
-          </Grid>
-        </Grid>
+        <CommonEditorAndOutput
+          codeTargetName="codeAnswer"
+          fileName={`/temp/file-${cohortStretchId}-${userDetails.id}.html`}
+          initialCode={codePrompt}
+          handleCodeChange={({ target }) => setStretchAnswer(target.value)}
+          {...{ language, editorTheme, fileGenerated, codeResponse, codeError }}
+        />
       </div>
     )
   }

--- a/client/Components/OpenStretchView/CodeSectionRun.js
+++ b/client/Components/OpenStretchView/CodeSectionRun.js
@@ -66,14 +66,29 @@ class CodeSectionRun extends Component {
       cohortStretchId,
       userDetails
     } = this.props
-    const startBarrierString = `${codePrompt}\n\n// Write your answer below this line --------------------------------\n`
-    const startBarrierData = {
-      length: startBarrierString.length,
-      numberOfLines: startBarrierString.split('\n').length - 2
+
+    let readOnlyLinesRegEx = {
+      solutionStart: /\/\/ Write your answer below this line/,
+      solutionEnd: /\/\/ Write your answer above this line/
     }
-    const endBarrierString = `// Write your answer above this line-----------------\n `
-    const endBarrierRegEx = /\/\/ Write your answer above this line-----------------/
-    const solutionAnnonated = `${startBarrierString}\n${endBarrierString}`
+
+    const jsxBarriers = {
+      string:
+        "\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))",
+      regExToCheck: {
+        render: /ReactDOM.render\(<App \/>,/,
+        string: /\/\/ Return component to render inside App component/,
+        appComponentStart: /const App = \(\) => {/,
+        appComponentEnd: /} \/\/ End Of App component/
+      }
+    }
+    if (language === 'jsx') {
+      readOnlyLinesRegEx = {
+        ...readOnlyLinesRegEx,
+        ...jsxBarriers.regExToCheck
+      }
+    }
+
     return (
       <div>
         <Grid container>
@@ -106,7 +121,9 @@ class CodeSectionRun extends Component {
         <CommonEditorAndOutput
           codeTargetName="studentAnswerRun"
           fileName={`/temp/file-${cohortStretchId}-${userDetails.id}.html`}
-          initialCode={solutionAnnonated}
+          initialCode={`// Code Prompt\n\n${codePrompt}\n\n// Write your answer below this line --------------------------------\n\n// Write your answer above this line----------\n${
+            language === 'jsx' ? jsxBarriers.string : ''
+          }`}
           handleCodeChange={({ target }) => setStretchAnswer(target.value)}
           changeCodeToRun={codeToRun => this.setState({ codeToRun })}
           {...{
@@ -115,8 +132,7 @@ class CodeSectionRun extends Component {
             fileGenerated,
             codeResponse,
             codeError,
-            startBarrierData,
-            endBarrierRegEx
+            readOnlyLinesRegEx
           }}
         />
       </div>

--- a/client/Components/OpenStretchView/CodeSectionRun.js
+++ b/client/Components/OpenStretchView/CodeSectionRun.js
@@ -104,7 +104,7 @@ class CodeSectionRun extends Component {
           </Grid>
         </Grid>
         <CommonEditorAndOutput
-          codeTargetName="studentAnswer"
+          codeTargetName="studentAnswerRun"
           fileName={`/temp/file-${cohortStretchId}-${userDetails.id}.html`}
           initialCode={solutionAnnonated}
           handleCodeChange={({ target }) => setStretchAnswer(target.value)}

--- a/client/Components/OpenStretchView/CodeSectionRun.js
+++ b/client/Components/OpenStretchView/CodeSectionRun.js
@@ -18,6 +18,7 @@ class CodeSectionRun extends Component {
     super()
     this.state = {
       editorTheme: 'monokai',
+      codeToRun: '',
       codeResponse: '',
       codeError: '',
       fileGenerated: false
@@ -50,7 +51,13 @@ class CodeSectionRun extends Component {
   }
 
   render() {
-    const { editorTheme, codeResponse, codeError, fileGenerated } = this.state
+    const {
+      editorTheme,
+      codeResponse,
+      codeError,
+      fileGenerated,
+      codeToRun
+    } = this.state
     const { runCodeBinded, clearCodeResultsBinded, handleChange } = this
     const {
       setStretchAnswer,
@@ -59,7 +66,14 @@ class CodeSectionRun extends Component {
       cohortStretchId,
       userDetails
     } = this.props
-    console.log(stretchAnswer)
+    const startBarrierString = `${codePrompt}\n\n// Write your answer below this line --------------------------------\n`
+    const startBarrierData = {
+      length: startBarrierString.length,
+      numberOfLines: startBarrierString.split('\n').length - 2
+    }
+    const endBarrierString = `// Write your answer above this line-----------------\n `
+    const endBarrierRegEx = /\/\/ Write your answer above this line-----------------/
+    const solutionAnnonated = `${startBarrierString}\n${endBarrierString}`
     return (
       <div>
         <Grid container>
@@ -73,7 +87,7 @@ class CodeSectionRun extends Component {
                   color="primary"
                   runCode={runCodeBinded}
                   postPayload={{
-                    code: stretchAnswer,
+                    code: codeToRun,
                     language,
                     fileName:
                       language === 'javascript'
@@ -90,11 +104,20 @@ class CodeSectionRun extends Component {
           </Grid>
         </Grid>
         <CommonEditorAndOutput
-          codeTargetName="codeAnswer"
+          codeTargetName="studentAnswer"
           fileName={`/temp/file-${cohortStretchId}-${userDetails.id}.html`}
-          initialCode={codePrompt}
+          initialCode={solutionAnnonated}
           handleCodeChange={({ target }) => setStretchAnswer(target.value)}
-          {...{ language, editorTheme, fileGenerated, codeResponse, codeError }}
+          changeCodeToRun={codeToRun => this.setState({ codeToRun })}
+          {...{
+            language,
+            editorTheme,
+            fileGenerated,
+            codeResponse,
+            codeError,
+            startBarrierData,
+            endBarrierRegEx
+          }}
         />
       </div>
     )

--- a/client/Components/SIngleClosedStretchViev/CodeSection.js
+++ b/client/Components/SIngleClosedStretchViev/CodeSection.js
@@ -13,9 +13,7 @@ import { editorsStyles } from './styles'
 class CodeSection extends Component {
   constructor(props) {
     super(props)
-    const cohortSolution = this.props.solutions.find(s =>
-      s.dropdownTitle.startsWith('Cohort')
-    )
+    const cohortSolution = this.props.solutions[0]
     this.state = {
       editorTheme: 'monokai',
       solution: cohortSolution ? cohortSolution.solution : ''

--- a/client/Components/SIngleClosedStretchViev/CodeSection.js
+++ b/client/Components/SIngleClosedStretchViev/CodeSection.js
@@ -13,8 +13,8 @@ import { editorsStyles } from './styles'
 class CodeSection extends Component {
   constructor(props) {
     super(props)
-    const cohortSolution = this.props.solutions.find(
-      s => s.dropdownTitle === 'Cohort Solution'
+    const cohortSolution = this.props.solutions.find(s =>
+      s.dropdownTitle.startsWith('Cohort')
     )
     this.state = {
       editorTheme: 'monokai',

--- a/client/Components/SIngleClosedStretchViev/CodeSection.js
+++ b/client/Components/SIngleClosedStretchViev/CodeSection.js
@@ -65,14 +65,14 @@ class CodeSection extends Component {
         <Grid container>
           <Grid item xs={6}>
             <SingleCodeComponent
-              savedCode={`${codePrompt}\n\n${studentAnswer}`}
+              savedCode={`// Code Prompt\n${codePrompt}\n\n// Your answer\n${studentAnswer}\n\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))`}
               editorId="student"
               {...{ stretchAnswerId, editorTheme, handleChange, language }}
             />
           </Grid>
           <Grid item xs={6}>
             <SingleCodeComponent
-              savedCode={`${codePrompt}\n\n${solution}`}
+              savedCode={`// Code Prompt\n${codePrompt}\n\n// Solution\n${solution}\n\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))`}
               editorId="admin"
               {...{ stretchAnswerId, editorTheme, handleChange, language }}
             />

--- a/client/Components/SIngleClosedStretchViev/SingleCodeComponent.js
+++ b/client/Components/SIngleClosedStretchViev/SingleCodeComponent.js
@@ -77,7 +77,6 @@ class SingleCodeComponent extends Component {
             appComponentEnd: /} \/\/ End Of App component/
           }
         : {}
-
     return (
       <Grid container>
         <Grid item xs={12}>

--- a/client/Components/SIngleClosedStretchViev/SingleCodeComponent.js
+++ b/client/Components/SIngleClosedStretchViev/SingleCodeComponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import React, { Component } from 'react'
 import axios from 'axios'
 import CodeEditor, {
@@ -66,6 +67,17 @@ class SingleCodeComponent extends Component {
     } = this.state
     const { editorTheme, editorId, language, stretchAnswerId } = this.props
     const { root } = editorsStyles()
+
+    let readOnlyLinesRegEx =
+      language === 'jsx'
+        ? {
+            render: /ReactDOM.render\(<App \/>,/,
+            string: /\/\/ Return component to render inside App component/,
+            appComponentStart: /const App = \(\) => {/,
+            appComponentEnd: /} \/\/ End Of App component/
+          }
+        : {}
+
     return (
       <Grid container>
         <Grid item xs={12}>
@@ -76,6 +88,7 @@ class SingleCodeComponent extends Component {
             editorId={editorId}
             initialCode={savedCode}
             language={language}
+            readOnlyLinesRegEx={readOnlyLinesRegEx}
           />
         </Grid>
         <Grid item xs={12} style={root}>

--- a/client/Components/SIngleClosedStretchViev/helperfunctions.js
+++ b/client/Components/SIngleClosedStretchViev/helperfunctions.js
@@ -1,5 +1,51 @@
 import moment from 'moment'
 
+const generateListOfSolutions = (
+  cohortStretches,
+  stretchId,
+  cohortId,
+  authorSolution
+) => {
+  let solutions = cohortStretches
+    .filter(cs => cs.stretchId === stretchId && cs.cohortSolution)
+    .map(cs => cs.cohortSolution)
+  let clickedCohortSolution = cohortStretches.find(
+    cs => cs.cohortId === cohortId
+  ).cohortSolution
+
+  let otherSolutionNumber = 1
+  solutions = [...solutions, authorSolution]
+    .reduce((acc, value) => {
+      console.log(acc)
+      if (!acc.includes(value)) acc.push(value)
+      return acc
+    }, [])
+    .reduce((acc, solution) => {
+      let dropdownTitle = ''
+      if ([clickedCohortSolution, authorSolution].includes(solution)) {
+        if (solution === clickedCohortSolution) {
+          dropdownTitle = 'Cohort'
+        }
+        if (solution === authorSolution) {
+          dropdownTitle = `${dropdownTitle}${
+            dropdownTitle === 'Cohort' ? '/' : ''
+          }Author`
+        }
+        dropdownTitle = `${dropdownTitle} Solution`
+      } else {
+        dropdownTitle = `Other Solution #${otherSolutionNumber}`
+        ++otherSolutionNumber
+      }
+      acc.push({ solution, dropdownTitle })
+      return acc
+    }, [])
+
+  return solutions.sort((a, b) => {
+    if (a.dropdownTitle.startsWith('Cohort')) return -1
+    return a.dropdownTitle - b.dropdownTitle
+  })
+}
+
 export const getStretchAnswerMetaData = (
   stretchAnswer,
   stretches,
@@ -27,22 +73,16 @@ export const getStretchAnswerMetaData = (
     title,
     textPrompt,
     codePrompt,
-    language
+    language,
+    authorSolution
   } = stretches.find(s => s.id === stretchId)
 
-  const solutions = cohortStretches
-    .filter(cs => cs.stretchId === stretchId)
-    .map(cs => {
-      return {
-        solution: cs.solution,
-        dropdownTitle:
-          cs.cohortId === cohortId ? 'Cohort Solution' : cs.cohortName
-      }
-    })
-    .sort((a, b) => {
-      if (a.dropdownTitle === 'Cohort Solution') return -1
-      return a.dropdownTitle - b.dropdownTitle
-    })
+  let solutions = generateListOfSolutions(
+    cohortStretches,
+    stretchId,
+    cohortId,
+    authorSolution
+  )
 
   const stretchMetaData = {
     stretchAnswerId: id,

--- a/client/Components/SIngleClosedStretchViev/helperfunctions.js
+++ b/client/Components/SIngleClosedStretchViev/helperfunctions.js
@@ -16,7 +16,6 @@ const generateListOfSolutions = (
   let otherSolutionNumber = 1
   solutions = [...solutions, authorSolution]
     .reduce((acc, value) => {
-      console.log(acc)
       if (!acc.includes(value)) acc.push(value)
       return acc
     }, [])

--- a/client/Components/SIngleClosedStretchViev/helperfunctions.js
+++ b/client/Components/SIngleClosedStretchViev/helperfunctions.js
@@ -38,10 +38,9 @@ const generateListOfSolutions = (
       acc.push({ solution, dropdownTitle })
       return acc
     }, [])
-
   return solutions.sort((a, b) => {
     if (a.dropdownTitle.startsWith('Cohort')) return -1
-    return a.dropdownTitle - b.dropdownTitle
+    return b.dropdownTitle - a.dropdownTitle
   })
 }
 

--- a/client/Components/SingleCohort/SingleCohort.js
+++ b/client/Components/SingleCohort/SingleCohort.js
@@ -1,19 +1,16 @@
-import React, { Component, useState } from 'react'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import Typography from '@material-ui/core/Typography'
 import { Link } from 'react-router-dom'
-import AppBar from '@material-ui/core/AppBar'
 import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
 import Button from '@material-ui/core/Button'
-import { makeStyles } from '@material-ui/core/styles'
 import { getAttendance } from '../../store/attendance/actions'
 import Grid from '@material-ui/core/Grid'
 import Calendar from 'react-calendar'
 import SingleCohortStretchTables from './SingleCohortStretchTables'
 import CohortStudents from './CohortStudents'
 import Attendance from './Attendance'
-
 
 class SingleCohort extends Component {
   state = {
@@ -51,12 +48,12 @@ class SingleCohort extends Component {
       >
         <Grid container spacing={2} style={{ width: '98%' }}>
           <Grid item xs={12}>
-            <Typography variant="h3">
-              {cohort.name}
-            </Typography>
-            <Link to={`/admin/cohort/analytics/${cohort.id}`}><Button variant="contained" color="primary">
-              Performance Analytics
-                </Button></Link>
+            <Typography variant="h3">{cohort.name}</Typography>
+            <Link to={`/admin/cohort/analytics/${cohort.id}`}>
+              <Button variant="contained" color="primary">
+                Performance Analytics
+              </Button>
+            </Link>
           </Grid>
           <Grid item xs={7}>
             <Grid item xs={12}>

--- a/client/Components/SingleCohort/SingleCohortStretchTables.js
+++ b/client/Components/SingleCohort/SingleCohortStretchTables.js
@@ -63,13 +63,7 @@ const SingleCohortStretchTables = ({ cohort, cohortStretches, stretches }) => {
         const { key, title } = table
         return (
           <div key={key}>
-            <ListItem
-              button
-              onClick={() => {
-                console.log(expandedTable)
-                setExpandTable(!expandedTable)
-              }}
-            >
+            <ListItem button onClick={() => setExpandTable(!expandedTable)}>
               <Grid container>
                 <Grid item xs={6}>
                   <Typography variant="h6" id="tableTitle">

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -48,13 +48,26 @@ class CodeInputSection extends Component {
     const { runCodeBinded, clearCodeResultsBinded } = this
     const { currentTab, codeResponse, codeError, fileGenerated } = this.state
     const {
-      initialCode,
+      initialCodePrompt,
+      initialSolution,
       language,
       mode,
       handleCodeChange,
       userDetails,
-      authorSolution
+      authorSolution,
+      codePrompt
     } = this.props
+    //  const startBarrierRegEx = new RegExp(initialCodePrompt)
+    //   `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
+    const startBarrierString = `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
+    console.log(startBarrierString.split('\n'))
+    const startBarrierData = {
+      length: startBarrierString.length,
+      numberOfLines: startBarrierString.split('\n').length - 2
+    }
+    const endBarrierString = `\n// Write the solution above this line-----------------\n `
+    const endBarrierRegEx = /\n\/\/ Write the solution above this line-----------------/
+    const solutionAnnonated = `${startBarrierString}${initialSolution}${endBarrierString}`
     return (
       <Grid container>
         <Grid item xs={12}>
@@ -73,11 +86,17 @@ class CodeInputSection extends Component {
           <Grid item xs={12}>
             {currentTab === 0 && (
               <CodeEditor
-                initialCode={initialCode}
+                initialCode={initialCodePrompt}
                 codeTargetName="codePrompt"
                 handleCodeChange={handleCodeChange}
                 language={language}
                 readOnly={mode === 'read'}
+                startBarrierData={startBarrierData}
+                onUnmount={() =>
+                  handleCodeChange({
+                    target: { name: 'initialCodePrompt', value: codePrompt }
+                  })
+                }
               />
             )}
             {currentTab === 1 && (
@@ -102,15 +121,23 @@ class CodeInputSection extends Component {
                 </Grid>
                 <CommonEditorAndOutput
                   codeTargetName="authorSolution"
-                  initialCode={authorSolution}
+                  initialCode={solutionAnnonated}
                   editorTheme="monokai"
                   fileName={`file-${userDetails.id}.html`}
+                  onUnmount={() =>
+                    handleCodeChange({
+                      target: { name: 'initialSolution', value: authorSolution }
+                    })
+                  }
+                  //startBarrierLength={startBarrierString.length}
                   {...{
                     language,
                     fileGenerated,
                     codeResponse,
                     codeError,
-                    handleCodeChange
+                    handleCodeChange,
+                    endBarrierRegEx,
+                    startBarrierData
                   }}
                 />
               </Grid>

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -21,6 +21,7 @@ class CodeInputSection extends Component {
     super()
     this.state = {
       currentTab: 0,
+      codeToRun: '',
       codeResponse: '',
       codeError: '',
       fileGenerated: false
@@ -60,14 +61,13 @@ class CodeInputSection extends Component {
     //  const startBarrierRegEx = new RegExp(initialCodePrompt)
     //   `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
     const startBarrierString = `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
-    console.log(startBarrierString.split('\n'))
     const startBarrierData = {
       length: startBarrierString.length,
       numberOfLines: startBarrierString.split('\n').length - 2
     }
-    const endBarrierString = `\n// Write the solution above this line-----------------\n `
-    const endBarrierRegEx = /\n\/\/ Write the solution above this line-----------------/
-    const solutionAnnonated = `${startBarrierString}${initialSolution}${endBarrierString}`
+    const endBarrierString = `// Write the solution above this line-----------------\n `
+    const endBarrierRegEx = /\/\/ Write the solution above this line-----------------/
+    const solutionAnnonated = `${startBarrierString}${initialSolution}\n${endBarrierString}`
     return (
       <Grid container>
         <Grid item xs={12}>
@@ -89,6 +89,7 @@ class CodeInputSection extends Component {
                 initialCode={initialCodePrompt}
                 codeTargetName="codePrompt"
                 handleCodeChange={handleCodeChange}
+                changeCodeToRun={codeToRun => this.setState({ codeToRun })}
                 language={language}
                 readOnly={mode === 'read'}
                 startBarrierData={startBarrierData}
@@ -106,7 +107,7 @@ class CodeInputSection extends Component {
                     color="primary"
                     runCode={runCodeBinded}
                     postPayload={{
-                      code: authorSolution,
+                      code: this.state.codeToRun,
                       language,
                       fileName:
                         language === 'javascript'
@@ -123,13 +124,13 @@ class CodeInputSection extends Component {
                   codeTargetName="authorSolution"
                   initialCode={solutionAnnonated}
                   editorTheme="monokai"
-                  fileName={`file-${userDetails.id}.html`}
+                  fileName={`/temp/file-${userDetails.id}.html`}
                   onUnmount={() =>
                     handleCodeChange({
                       target: { name: 'initialSolution', value: authorSolution }
                     })
                   }
-                  //startBarrierLength={startBarrierString.length}
+                  changeCodeToRun={codeToRun => this.setState({ codeToRun })}
                   {...{
                     language,
                     fileGenerated,

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -1,35 +1,130 @@
-import React, { useState } from 'react'
+import React, { Component } from 'react'
+import axios from 'axios'
 import { connect } from 'react-redux'
 import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
 import Grid from '@material-ui/core/Grid'
+import CodeEditor, {
+  AuxillaryComponents,
+  codeEditorFunctions
+} from '../CodeEditor'
+const { runCode, clearCodeResults } = codeEditorFunctions
+const {
+  ThemeSelector,
+  RunCodeButton,
+  ClearCodeResultsButton,
+  CommonEditorAndOutput
+} = AuxillaryComponents
 
-const CodeInputSection = () => {
-  let [currentTab, setTab] = useState(0)
-  return (
-    <Grid container>
-      <Grid item xs={12}>
-        <Tabs
-          value={currentTab}
-          onChange={(event, tab) => setTab(tab)}
-          indicatorColor="primary"
-          textColor="primary"
-          variant="fullWidth"
-          style={{ marginBottom: '2em' }}
-        >
-          <Tab label="Code Prompt" />
-          <Tab label="Solution" />
-        </Tabs>
+class CodeInputSection extends Component {
+  constructor() {
+    super()
+    this.state = {
+      currentTab: 0,
+      codeResponse: '',
+      codeError: '',
+      fileGenerated: false
+    }
+    this.runCodeBinded = runCode.bind(this)
+    this.clearCodeResultsBinded = clearCodeResults.bind(this)
+  }
+
+  componentDidMount() {
+    this.removeTemporaryUserFiles()
+  }
+
+  componentWillUnmount() {
+    this.removeTemporaryUserFiles()
+  }
+
+  removeTemporaryUserFiles() {
+    const { language, userDetails } = this.props
+    if (language === 'jsx') {
+      axios.delete(`/api/code/file-${userDetails.id}`)
+    }
+  }
+
+  render() {
+    const { runCodeBinded, clearCodeResultsBinded } = this
+    const { currentTab, codeResponse, codeError, fileGenerated } = this.state
+    const {
+      initialCode,
+      language,
+      mode,
+      handleCodeChange,
+      userDetails,
+      authorSolution
+    } = this.props
+    return (
+      <Grid container>
+        <Grid item xs={12}>
+          <Tabs
+            value={currentTab}
+            onChange={(event, tab) => this.setState({ currentTab: tab })}
+            indicatorColor="primary"
+            textColor="primary"
+            variant="fullWidth"
+            style={{ marginBottom: '2em' }}
+          >
+            <Tab label="Code Prompt" />
+            <Tab label="Solution" />
+          </Tabs>
+
+          <Grid item xs={12}>
+            {currentTab === 0 && (
+              <CodeEditor
+                initialCode={initialCode}
+                codeTargetName="codePrompt"
+                handleCodeChange={handleCodeChange}
+                language={language}
+                readOnly={mode === 'read'}
+              />
+            )}
+            {currentTab === 1 && (
+              <Grid container>
+                <Grid item xs={12}>
+                  <RunCodeButton
+                    color="primary"
+                    runCode={runCodeBinded}
+                    postPayload={{
+                      code: authorSolution,
+                      language,
+                      fileName:
+                        language === 'javascript'
+                          ? ''
+                          : `file-${userDetails.id}`
+                    }}
+                  />
+                  <ClearCodeResultsButton
+                    color="secondary"
+                    clearCodeResults={clearCodeResultsBinded}
+                  />
+                </Grid>
+                <CommonEditorAndOutput
+                  codeTargetName="authorSolution"
+                  initialCode={authorSolution}
+                  editorTheme="monokai"
+                  fileName={`file-${userDetails.id}.html`}
+                  {...{
+                    language,
+                    fileGenerated,
+                    codeResponse,
+                    codeError,
+                    handleCodeChange
+                  }}
+                />
+              </Grid>
+            )}
+          </Grid>
+        </Grid>
       </Grid>
-    </Grid>
-  )
+    )
+  }
 }
-
-const mapStateToProps = state => ({})
 
 const mapDispatchToProps = {}
 
 export default connect(
-  mapStateToProps,
+  ({ userDetails }) => ({ userDetails }),
   mapDispatchToProps
 )(CodeInputSection)

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -54,7 +54,6 @@ class CodeInputSection extends Component {
       handleCodeChange,
       userDetails
     } = this.props
-
     let readOnlyLinesRegEx = {
       codePrompt: /\/\/ Write the code prompt below this line/,
       solutionStart: /\/\/ Write the solution below this line/,
@@ -80,7 +79,8 @@ class CodeInputSection extends Component {
 
     let solutionAnnonated
     if (mode === 'create') {
-      solutionAnnonated = `// Write the code prompt below this line------\n\n${initialCodePrompt}// Write the solution below this line---------\n\n${initialSolution}// Write the solution above this line----------\n${
+      solutionAnnonated = `// Write the code prompt below this line------\n\n${initialCodePrompt}\n\n// Write the solution below this line---------\n\n${initialSolution ||
+        ''}\n// Write the solution above this line----------\n${
         language === 'jsx' ? jsxBarriers.string : ''
       }`
     } else if (mode === 'read') {

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+import { connect } from 'react-redux'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
+import Grid from '@material-ui/core/Grid'
+
+const CodeInputSection = () => {
+  let [currentTab, setTab] = useState(0)
+  return (
+    <Grid container>
+      <Grid item xs={12}>
+        <Tabs
+          value={currentTab}
+          onChange={(event, tab) => setTab(tab)}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="fullWidth"
+          style={{ marginBottom: '2em' }}
+        >
+          <Tab label="Code Prompt" />
+          <Tab label="Solution" />
+        </Tabs>
+      </Grid>
+    </Grid>
+  )
+}
+
+const mapStateToProps = state => ({})
+
+const mapDispatchToProps = {}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CodeInputSection)

--- a/client/Components/SingleStretch/CodeInputSection.js
+++ b/client/Components/SingleStretch/CodeInputSection.js
@@ -58,16 +58,27 @@ class CodeInputSection extends Component {
       authorSolution,
       codePrompt
     } = this.props
-    //  const startBarrierRegEx = new RegExp(initialCodePrompt)
-    //   `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
-    const startBarrierString = `${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
+    const startBarrierString = `// Code Prompt\n${initialCodePrompt}\n\n// Write the soluton below this line --------------------------------\n`
     const startBarrierData = {
       length: startBarrierString.length,
-      numberOfLines: startBarrierString.split('\n').length - 2
+      numberOfLines: startBarrierString.split('\n').length - 2,
+      lastLine:
+        'Write the soluton below this line --------------------------------'
     }
     const endBarrierString = `// Write the solution above this line-----------------\n `
     const endBarrierRegEx = /\/\/ Write the solution above this line-----------------/
-    const solutionAnnonated = `${startBarrierString}${initialSolution}\n${endBarrierString}`
+    const jsxBarriers = {
+      string:
+        "\n//Put component to render as first argument in ReactDOM.render\nReactDOM.render(\n\n,document.querySelector('#app'))",
+      regExToCheck: {
+        render: /ReactDOM.render\(/,
+        querySelector: /,document.querySelector\('#app'\)\)/,
+        string: /\/\/Put component to render as first argument in ReactDOM.render/
+      }
+    }
+    const solutionAnnonated = `${startBarrierString}${initialSolution}\n${endBarrierString}${
+      language === 'jsx' ? jsxBarriers.string : ''
+    }`
     return (
       <Grid container>
         <Grid item xs={12}>
@@ -138,7 +149,8 @@ class CodeInputSection extends Component {
                     codeError,
                     handleCodeChange,
                     endBarrierRegEx,
-                    startBarrierData
+                    startBarrierData,
+                    jsxBarriers
                   }}
                 />
               </Grid>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -22,7 +22,9 @@ class SingleStretch extends Component {
     title: 'Untitled',
     categoryId: '',
     textPrompt: 'This is an example text prompt.',
-    codePrompt: '// This is an example code prompt.',
+    codePrompt:
+      '// This is an example code prompt.\n// emxampleFunction(3) = 5',
+    authorSolution: '',
     difficulty: 3,
     minutes: '',
     language: 'javascript',
@@ -47,8 +49,6 @@ class SingleStretch extends Component {
     const { name, value } = event.target
     this.setState({ [name]: value })
   }
-
-  handleCodeChange = codePrompt => this.setState({ codePrompt })
 
   // This function is called when SingleStretch is in 'create' or 'update' mode.
   handleSubmit = event => {
@@ -115,7 +115,15 @@ class SingleStretch extends Component {
     const { state } = this
     const { handleSubmit, changeMode } = this
     const { handleChange, notScheduleStretch } = this
-    const { mode, authorId, language, modalOpen, stretchId } = state
+    const {
+      mode,
+      authorId,
+      language,
+      modalOpen,
+      stretchId,
+      initialCode,
+      authorSolution
+    } = state
 
     return (
       <div>
@@ -173,13 +181,9 @@ class SingleStretch extends Component {
               </Grid>
 
               <Grid item xs={12}>
-                <CodeInputSection />
-                <CodeEditor
-                  initialCode={state.initialCode}
-                  codeTargetName="codePrompt"
+                <CodeInputSection
                   handleCodeChange={handleChange}
-                  language={language}
-                  readOnly={mode === 'read'}
+                  {...{ initialCode, language, mode, authorSolution }}
                 />
               </Grid>
             </Grid>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -30,7 +30,10 @@ class SingleStretch extends Component {
     language: 'javascript',
     authorId: '',
     isLoaded: false,
-    modalOpen: false
+    modalOpen: false,
+    initialCodePrompt:
+      '// This is an example code prompt.\n// emxampleFunction(3) = 5',
+    initalSolution: ''
   }
 
   // This method changes the mode of the view. The valid modes are 'read', 'update', and 'create'.
@@ -40,9 +43,18 @@ class SingleStretch extends Component {
     const { match, mode, stretches } = this.props
 
     let attributes = {}
-    if (match.params.id && stretches.length)
-      attributes = stretches.find(s => s.id === match.params.id)
-    this.setState({ mode, ...attributes, initialCode: attributes.codePrompt })
+    //if (match.params.id && stretches.length) {
+    const stretch = stretches.find(s => s.id === match.params.id) || {}
+    attributes = {
+      ...stretch,
+      initialCodePrompt: stretch.codePrompt || '',
+      initialSolution: stretch.authorSolution || ''
+    }
+    // }
+    this.setState({
+      mode,
+      ...attributes
+    })
   }
 
   handleChange = event => {
@@ -121,10 +133,11 @@ class SingleStretch extends Component {
       language,
       modalOpen,
       stretchId,
-      initialCode,
-      authorSolution
+      initialCodePrompt,
+      initialSolution,
+      authorSolution,
+      codePrompt
     } = state
-
     return (
       <div>
         <StretchScheduler
@@ -168,7 +181,6 @@ class SingleStretch extends Component {
                     label="Text Prompt"
                     value={state.textPrompt}
                     placeholder="Enter your written prompt here."
-                    helperText="This is to be substituted with a rich text editor."
                     fullWidth
                     multiline={true}
                     margin="normal"
@@ -183,7 +195,14 @@ class SingleStretch extends Component {
               <Grid item xs={12}>
                 <CodeInputSection
                   handleCodeChange={handleChange}
-                  {...{ initialCode, language, mode, authorSolution }}
+                  {...{
+                    initialCodePrompt,
+                    initialSolution,
+                    language,
+                    mode,
+                    authorSolution,
+                    codePrompt
+                  }}
                 />
               </Grid>
             </Grid>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -12,6 +12,7 @@ import Controls from './Controls'
 import GeneralInfo from './GeneralInfo'
 import CodeEditor from '../CodeEditor'
 import StretchScheduler from '../_shared/StretchScheduler'
+import CodeInputSection from './CodeInputSection'
 
 import { GeneralInfoStyles, SingleStretchStyles as styles } from './styles'
 
@@ -172,6 +173,7 @@ class SingleStretch extends Component {
               </Grid>
 
               <Grid item xs={12}>
+                <CodeInputSection />
                 <CodeEditor
                   initialCode={state.initialCode}
                   codeTargetName="codePrompt"

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -90,7 +90,7 @@ class SingleStretch extends Component {
     }
 
     if (this.state.mode === 'create') {
-      data.codePrompt += `\n \n/*your code below --------------------------------------------------------------*/`
+      // data.codePrompt += `\n \n/*your code below --------------------------------------------------------------*/`
       this.props
         .createStretch({ ...data, authorId: this.props.userDetails.id })
         .then(({ newStretch: { id } }) =>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -21,8 +21,7 @@ class SingleStretch extends Component {
     title: 'Untitled',
     categoryId: '',
     textPrompt: 'This is an example text prompt.',
-    codePrompt:
-      '// This is an example code prompt.\n// emxampleFunction(3) = 5',
+    codePrompt: '',
     authorSolution: '',
     difficulty: 3,
     minutes: '',
@@ -89,7 +88,7 @@ class SingleStretch extends Component {
     }
 
     if (this.state.mode === 'create') {
-      data.codePrompt = `// Code Prompt\n${data.codePrompt}`
+      //data.codePrompt = `// Code Prompt\n${data.codePrompt}`
       this.props
         .createStretch({ ...data, authorId: this.props.userDetails.id })
         .then(({ newStretch: { id } }) =>

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -17,7 +17,7 @@ import { GeneralInfoStyles, SingleStretchStyles as styles } from './styles'
 
 class SingleStretch extends Component {
   state = {
-    mode: 'read',
+    mode: this.props.mode || 'read',
     title: 'Untitled',
     categoryId: '',
     textPrompt: 'This is an example text prompt.',

--- a/client/Components/SingleStretch/SingleStretch.js
+++ b/client/Components/SingleStretch/SingleStretch.js
@@ -10,7 +10,6 @@ import Typography from '@material-ui/core/Typography'
 
 import Controls from './Controls'
 import GeneralInfo from './GeneralInfo'
-import CodeEditor from '../CodeEditor'
 import StretchScheduler from '../_shared/StretchScheduler'
 import CodeInputSection from './CodeInputSection'
 
@@ -90,7 +89,7 @@ class SingleStretch extends Component {
     }
 
     if (this.state.mode === 'create') {
-      // data.codePrompt += `\n \n/*your code below --------------------------------------------------------------*/`
+      data.codePrompt = `// Code Prompt\n${data.codePrompt}`
       this.props
         .createStretch({ ...data, authorId: this.props.userDetails.id })
         .then(({ newStretch: { id } }) =>

--- a/client/Components/StretchReviewView/CodeSection.js
+++ b/client/Components/StretchReviewView/CodeSection.js
@@ -19,7 +19,10 @@ class CodeSection extends Component {
     this.state = {
       editorTheme: 'monokai',
       classroomCode: '',
-      solution: this.props.outlinedCode,
+      solution:
+        this.props.language === 'jsx'
+          ? "\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))"
+          : '',
       codeResponse: '',
       codeError: '',
       fileGenerated: false
@@ -50,7 +53,12 @@ class CodeSection extends Component {
   }
 
   showSolution = () => {
-    this.setState({ solution: this.props.solution })
+    this.setState(prevState => {
+      let solution = `// Code Prompt\n\n${this.props.codePrompt}\n\n${
+        this.props.solution
+      }${prevState.solution}`
+      return { solution }
+    })
   }
 
   render() {
@@ -68,7 +76,18 @@ class CodeSection extends Component {
       handleChange,
       showSolution
     } = this
-    const { language, cohortStretchId, jsxBarriers } = this.props
+    const { language, cohortStretchId } = this.props
+
+    let readOnlyLinesRegEx =
+      language === 'jsx'
+        ? {
+            render: /ReactDOM.render\(<App \/>,/,
+            string: /\/\/ Return component to render inside App component/,
+            appComponentStart: /const App = \(\) => {/,
+            appComponentEnd: /} \/\/ End Of App component/
+          }
+        : {}
+
     return (
       <div>
         <Grid container>
@@ -117,7 +136,7 @@ class CodeSection extends Component {
             fileGenerated,
             codeResponse,
             codeError,
-            jsxBarriers
+            readOnlyLinesRegEx
           }}
         />
       </div>

--- a/client/Components/StretchReviewView/CodeSection.js
+++ b/client/Components/StretchReviewView/CodeSection.js
@@ -1,21 +1,17 @@
 import React, { Component } from 'react'
 import axios from 'axios'
-import CodeEditor, {
-  AuxillaryComponents,
-  codeEditorFunctions
-} from '../CodeEditor'
+import { AuxillaryComponents, codeEditorFunctions } from '../CodeEditor'
 const { runCode, clearCodeResults } = codeEditorFunctions
 const {
   ThemeSelector,
   RunCodeButton,
   ClearCodeResultsButton,
-  CodeOutput
+  CommonEditorAndOutput
 } = AuxillaryComponents
 
 import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 import { codeSectionStyles } from './styles'
-import Typography from '@material-ui/core/Typography'
 
 class CodeSection extends Component {
   constructor() {
@@ -110,47 +106,13 @@ class CodeSection extends Component {
             </Grid>
           </Grid>
         </Grid>
-        <Grid container>
-          <Grid item xs={6}>
-            <CodeEditor
-              codeTargetName="code"
-              initialCode={solution}
-              editorTheme={editorTheme}
-              handleCodeChange={handleChange}
-              language={language}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            {language === 'jsx' && (
-              <Typography
-                variant="subtitle2"
-                style={codeSectionStyles.outputLabels}
-              >
-                JSX Rendering
-              </Typography>
-            )}
-
-            {language === 'jsx' && (
-              <iframe
-                src={fileGenerated ? `/temp/file-${cohortStretchId}.html` : ''}
-                style={codeSectionStyles.iframe}
-              />
-            )}
-            {language === 'jsx' && (
-              <Typography
-                variant="subtitle2"
-                style={codeSectionStyles.outputLabels}
-              >
-                Console
-              </Typography>
-            )}
-            <CodeOutput
-              codeResponse={codeResponse}
-              codeError={codeError}
-              minHeight={`${language === 'jsx' ? '10' : '23'}rem`}
-            />
-          </Grid>
-        </Grid>
+        <CommonEditorAndOutput
+          codeTargetName="code"
+          fileName={`/temp/file-${cohortStretchId}.html`}
+          initialCode={solution}
+          handleCodeChange={handleChange}
+          {...{ language, editorTheme, fileGenerated, codeResponse, codeError }}
+        />
       </div>
     )
   }

--- a/client/Components/StretchReviewView/CodeSection.js
+++ b/client/Components/StretchReviewView/CodeSection.js
@@ -14,12 +14,12 @@ import Button from '@material-ui/core/Button'
 import { codeSectionStyles } from './styles'
 
 class CodeSection extends Component {
-  constructor() {
-    super()
+  constructor(props) {
+    super(props)
     this.state = {
       editorTheme: 'monokai',
-      code: '',
-      solution: '',
+      classroomCode: '',
+      solution: this.props.outlinedCode,
       codeResponse: '',
       codeError: '',
       fileGenerated: false
@@ -56,7 +56,7 @@ class CodeSection extends Component {
   render() {
     const {
       editorTheme,
-      code,
+      classroomCode,
       codeResponse,
       codeError,
       solution,
@@ -68,7 +68,7 @@ class CodeSection extends Component {
       handleChange,
       showSolution
     } = this
-    const { language, cohortStretchId } = this.props
+    const { language, cohortStretchId, jsxBarriers } = this.props
     return (
       <div>
         <Grid container>
@@ -92,7 +92,7 @@ class CodeSection extends Component {
                   color="primary"
                   runCode={runCodeBinded}
                   postPayload={{
-                    code,
+                    code: classroomCode,
                     language,
                     fileName:
                       language === 'javascript' ? '' : `file-${cohortStretchId}`
@@ -107,11 +107,18 @@ class CodeSection extends Component {
           </Grid>
         </Grid>
         <CommonEditorAndOutput
-          codeTargetName="code"
+          codeTargetName="classroomCode"
           fileName={`/temp/file-${cohortStretchId}.html`}
           initialCode={solution}
           handleCodeChange={handleChange}
-          {...{ language, editorTheme, fileGenerated, codeResponse, codeError }}
+          {...{
+            language,
+            editorTheme,
+            fileGenerated,
+            codeResponse,
+            codeError,
+            jsxBarriers
+          }}
         />
       </div>
     )

--- a/client/Components/StretchReviewView/CodeSection.js
+++ b/client/Components/StretchReviewView/CodeSection.js
@@ -53,10 +53,14 @@ class CodeSection extends Component {
   }
 
   showSolution = () => {
-    this.setState(prevState => {
-      let solution = `// Code Prompt\n\n${this.props.codePrompt}\n\n${
-        this.props.solution
-      }${prevState.solution}`
+    this.setState(() => {
+      let solution = `// Code Prompt\n\n${
+        this.props.codePrompt
+      }\n\n// Solution\n\n${this.props.solution}${
+        this.props.language === 'jsx'
+          ? "\n// Return component to render inside App component\nconst App = () => {\n\n} // End Of App component\n\nReactDOM.render(<App />,document.querySelector('#app'))"
+          : ''
+      }`
       return { solution }
     })
   }

--- a/client/Components/StretchReviewView/StretchReviewView.js
+++ b/client/Components/StretchReviewView/StretchReviewView.js
@@ -23,16 +23,6 @@ const StretchReviewView = ({
   } = attributes
   const { language } = otherStretchFields
 
-  const jsxBarriers = {
-    string:
-      "\n//Put component to render as first argument in ReactDOM.render\nReactDOM.render(\n\n,document.querySelector('#app'))",
-    regExToCheck: {
-      render: /ReactDOM.render\(/,
-      querySelector: /,document.querySelector\('#app'\)\)/,
-      string: /\/\/Put component to render as first argument in ReactDOM.render/
-    }
-  }
-
   return (
     <div>
       <GeneralInfo attributes={otherStretchFields} />
@@ -53,12 +43,10 @@ const StretchReviewView = ({
         </Grid>
         <Grid item xs={12}>
           <CodeSection
-            outlinedCode={language === 'jsx' ? jsxBarriers.string : ''}
-            solution={`${codePrompt}\n\n${currentCohortStretch.cohortSolution ||
-              authorSolution}\n${language === 'jsx' ? jsxBarriers.string : ''}`}
+            codePrompt={codePrompt}
+            solution={currentCohortStretch.cohortSolution || authorSolution}
             language={language}
             cohortStretchId={cohortStretchId}
-            jsxBarriers={jsxBarriers}
           />
         </Grid>
       </Grid>

--- a/client/Components/StretchReviewView/StretchReviewView.js
+++ b/client/Components/StretchReviewView/StretchReviewView.js
@@ -14,7 +14,13 @@ const StretchReviewView = ({
   cohortStretchId
 }) => {
   if (!attributes) return <div>Data still loading</div>
-  const { textPrompt, codePrompt, ...otherStretchFields } = attributes
+
+  const {
+    textPrompt,
+    codePrompt,
+    authorSolution,
+    ...otherStretchFields
+  } = attributes
 
   return (
     <div>
@@ -36,7 +42,8 @@ const StretchReviewView = ({
         </Grid>
         <Grid item xs={12}>
           <CodeSection
-            solution={`${codePrompt}\n\n${currentCohortStretch.solution}`}
+            solution={`${codePrompt}\n\n${currentCohortStretch.cohortSolution ||
+              authorSolution}`}
             language={otherStretchFields.language}
             cohortStretchId={cohortStretchId}
           />

--- a/client/Components/StretchReviewView/StretchReviewView.js
+++ b/client/Components/StretchReviewView/StretchReviewView.js
@@ -21,6 +21,17 @@ const StretchReviewView = ({
     authorSolution,
     ...otherStretchFields
   } = attributes
+  const { language } = otherStretchFields
+
+  const jsxBarriers = {
+    string:
+      "\n//Put component to render as first argument in ReactDOM.render\nReactDOM.render(\n\n,document.querySelector('#app'))",
+    regExToCheck: {
+      render: /ReactDOM.render\(/,
+      querySelector: /,document.querySelector\('#app'\)\)/,
+      string: /\/\/Put component to render as first argument in ReactDOM.render/
+    }
+  }
 
   return (
     <div>
@@ -42,10 +53,12 @@ const StretchReviewView = ({
         </Grid>
         <Grid item xs={12}>
           <CodeSection
+            outlinedCode={language === 'jsx' ? jsxBarriers.string : ''}
             solution={`${codePrompt}\n\n${currentCohortStretch.cohortSolution ||
-              authorSolution}`}
-            language={otherStretchFields.language}
+              authorSolution}\n${language === 'jsx' ? jsxBarriers.string : ''}`}
+            language={language}
             cohortStretchId={cohortStretchId}
+            jsxBarriers={jsxBarriers}
           />
         </Grid>
       </Grid>

--- a/client/Components/_shared/CategorySelect.js
+++ b/client/Components/_shared/CategorySelect.js
@@ -11,7 +11,6 @@ import InputLabel from '@material-ui/core/InputLabel'
 const CategorySelect = props => {
   const { categories, categoryId, style } = props
   const { handleChange } = props
-
   if (!categories) return null
 
   return (

--- a/client/Components/_shared/CohortSelect.js
+++ b/client/Components/_shared/CohortSelect.js
@@ -9,7 +9,6 @@ import InputLabel from '@material-ui/core/InputLabel'
 const CohortSelect = props => {
   const { style, cohorts, cohortId } = props
   const { handleChange } = props
-
   return (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <div>

--- a/client/Components/_shared/DropdownSelect.js
+++ b/client/Components/_shared/DropdownSelect.js
@@ -15,7 +15,6 @@ const DropdownSelect = props => {
     label
   } = props
   const { handleChange } = props
-
   if (!data) return null
 
   return (
@@ -41,7 +40,7 @@ const DropdownSelect = props => {
 
 DropdownSelect.defaultProps = {
   style: { width: '100%' },
-  handleChange: () => { }
+  handleChange: () => {}
 }
 
 export default DropdownSelect

--- a/server/api/code-edtior-functions.js
+++ b/server/api/code-edtior-functions.js
@@ -58,7 +58,7 @@ const runTranspiledCode = (transpiledCode, fileName) => {
 
 //process JSX code coming in from client
 const processUserJSXCode = async (fileName, code) => {
-  const codeForBabel = `${code}; ReactDOM.render(<App />, document.querySelector('#app'))`
+  //const codeForBabel = `${code}; ReactDOM.render(<App />, document.querySelector('#app'))`
   const userFilesDir = path.join(__dirname, '..', '..', 'TempUserFiles')
   const htmlFileStart = `<!DOCTYPE html>
     <html lang="en">
@@ -76,12 +76,9 @@ const processUserJSXCode = async (fileName, code) => {
             </body>
         </html>`
 
-  await writeFilePromise(
-    path.join(userFilesDir, `${fileName}.js`),
-    codeForBabel
-  )
+  await writeFilePromise(path.join(userFilesDir, `${fileName}.js`), code)
   const transpiledCode = await babelTransformPromise(
-    codeForBabel,
+    code,
     path.join(userFilesDir, `${fileName}.js`)
   )
 

--- a/server/db/models/CohortStretch.js
+++ b/server/db/models/CohortStretch.js
@@ -21,7 +21,7 @@ const CohortStretch = db.define('cohortstretch', {
       notEmpty: true
     }
   },
-  solution: {
+  cohortSolution: {
     type: db.Sequelize.TEXT,
     defaultValue: `const solution = console.log('Default solution for a cohort stretch. You did it!')`,
     allowNull: false,
@@ -36,11 +36,7 @@ const CohortStretch = db.define('cohortstretch', {
     type: db.Sequelize.DATE,
     allowNull: false,
     validate: {
-      notEmpty: true,
-      afterCurrentDate(value) {
-        // if (value < Date.now())
-        // throw new Error('Can not schedule stretch for before right now')
-      }
+      notEmpty: true
     }
   }
 })

--- a/server/db/models/CohortStretch.js
+++ b/server/db/models/CohortStretch.js
@@ -22,12 +22,7 @@ const CohortStretch = db.define('cohortstretch', {
     }
   },
   cohortSolution: {
-    type: db.Sequelize.TEXT,
-    defaultValue: `const solution = console.log('Default solution for a cohort stretch. You did it!')`,
-    allowNull: false,
-    validate: {
-      notEmpty: true
-    }
+    type: db.Sequelize.TEXT
   },
   startTimer: {
     type: db.Sequelize.DATE

--- a/server/db/models/Stretch.js
+++ b/server/db/models/Stretch.js
@@ -38,7 +38,7 @@ const Stretch = db.define('stretch', {
       min: 1
     }
   },
-  solution: {
+  authorSolution: {
     type: db.Sequelize.TEXT,
     defaultValue: `const solution = console.log('You did it!')`,
     allowNull: false,

--- a/server/db/models/StretchAnswer.js
+++ b/server/db/models/StretchAnswer.js
@@ -7,11 +7,7 @@ const StretchAnswer = db.define('stretchanswer', {
     primaryKey: true
   },
   body: {
-    type: db.Sequelize.TEXT,
-    allowNull: false,
-    validate: {
-      notEmpty: true
-    }
+    type: db.Sequelize.TEXT
   },
   isSolved: {
     type: db.Sequelize.BOOLEAN


### PR DESCRIPTION
Admins now have the ability to create solutions in app, with the workflow as detailed below
- Stretch model has required authorSolution field and CohortStretch model has non-required cohortSolution field
- When admin creates stretch, single editor appears for both code prompt and authorSolution
- When admin schedules stretch, if
         - admin is author, modal appears with no option to create cohortSolution
         - admin is NOT author, goes to page of CohortStretch creation where they can look at author solution and add their own solution if they like

I also created a partially editable code editor. What I mean by this is any time there is a code editor, some lines can not be edited while the rest of the code editor can be written in. Did this for generally two purposes
- situations where have code prompt in code editor just for display but not be saved and want to ensure people always able to view code prompt, i.e. don't accidentally delete it, and that people always delete lines marking where to put in saved code
- for jsx, ensuring people always using component called App for rendering